### PR TITLE
Fixed boolean logic typo at end of C loader.

### DIFF
--- a/glad/loader/gl/c.py
+++ b/glad/loader/gl/c.py
@@ -161,7 +161,7 @@ class OpenGLCLoader(BaseLoader):
         fobj.write('\tif(glGetString(GL_VERSION) == NULL) return 0;\n')
 
     def write_end_load(self, fobj):
-        fobj.write('\treturn GLVersion.major != 0 && GLVersion.minor != 0;\n')
+        fobj.write('\treturn GLVersion.major != 0 || GLVersion.minor != 0;\n')
 
     def write_find_core(self, fobj):
         fobj.write(_FIND_VERSION);


### PR DESCRIPTION
Any OpenGL version where either version major or minor component of the
version number is zero would be handled incorrectly due to a very easy
mistake that is hard to run into if you don't test on with an OpenGL
version that's affected!

Thanks for finding the bug go to @rtmf

Should close issue #14
