### PR TITLE
Fixed deprecation error for VC++ in C generator

### DIFF
--- a/glad/loader/gl/c.py
+++ b/glad/loader/gl/c.py
@@ -144,7 +144,7 @@ _FIND_VERSION = '''
         }
     }
 
-#ifdef _WIN32
+#ifdef _MSC_VER
     sscanf_s(version, "%d.%d", &major, &minor);
 #else
     sscanf(version, "%d.%d", &major, &minor);

--- a/glad/loader/gl/c.py
+++ b/glad/loader/gl/c.py
@@ -144,7 +144,11 @@ _FIND_VERSION = '''
         }
     }
 
+#ifdef _WIN32
+    sscanf_s(version, "%d.%d", &major, &minor);
+#else
     sscanf(version, "%d.%d", &major, &minor);
+#endif
     GLVersion.major = major; GLVersion.minor = minor;
 '''
 


### PR DESCRIPTION
Visal C++ complier has deprecated sscanf() and replaced it with sscanf_s(). Using the former will cause a compilation error.