### PR TITLE
Get OpenGL extensions strings only once.

### DIFF
--- a/glad/lang/c/generator.py
+++ b/glad/lang/c/generator.py
@@ -79,6 +79,7 @@ class CGenerator(Generator):
 
             f.write('static void find_extensions{}(void) {{\n'.format(api.upper()))
             if self.spec.NAME in ('gl', 'glx', 'wgl'):
+                f.write('\tget_exts();\n')
                 for ext in extensions[api]:
                     f.write('\tGLAD_{0} = has_ext("{0}");\n'.format(ext.name))
             f.write('}\n\n')
@@ -216,7 +217,7 @@ class CGenerator(Generator):
                 f.write('GLAPI int gladLoad{}Loader(GLADloadproc);\n\n'.format(api.upper()))
 
     def write_code_head(self, f):
-        f.write('#include <stdio.h>\n#include <string.h>\n#include {}\n'.format(self.h_include))
+        f.write('#include <stdio.h>\n#include <stdlib.h>\n#include <string.h>\n#include {}\n'.format(self.h_include))
 
     def write_extern(self, fobj):
         fobj.write('#ifdef __cplusplus\nextern "C" {\n#endif\n')

--- a/glad/lang/c/loader/gl.py
+++ b/glad/lang/c/loader/gl.py
@@ -24,6 +24,32 @@ struct gladGLversionStruct GLVersion;
 #define _GLAD_IS_SOME_NEW_VERSION 1
 #endif
 
+static const char *exts = NULL;
+static int num_exts_i = 0;
+static const char **exts_i = NULL;
+
+static void get_exts(void) {
+#ifdef _GLAD_IS_SOME_NEW_VERSION
+    if(GLVersion.major < 3) {
+#endif
+        exts = (const char *)glGetString(GL_EXTENSIONS);
+#ifdef _GLAD_IS_SOME_NEW_VERSION
+    } else {
+        int index;
+
+        num_exts_i = 0;
+        glGetIntegerv(GL_NUM_EXTENSIONS, &num_exts_i);
+        if (num_exts_i > 0) {
+            exts_i = (const char **)realloc((void *)exts_i, num_exts_i * sizeof *exts_i);
+        }
+
+        for(index = 0; index < num_exts_i; index++) {
+            exts_i[index] = (const char*)glGetStringi(GL_EXTENSIONS, index);
+        }
+    }
+#endif
+}
+
 static int has_ext(const char *ext) {
 #ifdef _GLAD_IS_SOME_NEW_VERSION
     if(GLVersion.major < 3) {
@@ -31,7 +57,7 @@ static int has_ext(const char *ext) {
         const char *extensions;
         const char *loc;
         const char *terminator;
-        extensions = (const char *)glGetString(GL_EXTENSIONS);
+        extensions = exts;
         if(extensions == NULL || ext == NULL) {
             return 0;
         }
@@ -51,12 +77,10 @@ static int has_ext(const char *ext) {
         }
 #ifdef _GLAD_IS_SOME_NEW_VERSION
     } else {
-        int num, index;
+        int index;
 
-        glGetIntegerv(GL_NUM_EXTENSIONS, &num);
-
-        for(index = 0; index < num; index++) {
-            const char *e = (const char*)glGetStringi(GL_EXTENSIONS, index);
+        for(index = 0; index < num_exts_i; index++) {
+            const char *e = exts_i[index];
 
             if(strcmp(e, ext) == 0) {
                 return 1;

--- a/glad/lang/c/loader/glx.py
+++ b/glad/lang/c/loader/glx.py
@@ -61,6 +61,9 @@ _GLX_HAS_EXT = '''
 static Display *GLADGLXDisplay = 0;
 static int GLADGLXscreen = 0;
 
+static void get_exts(void) {
+}
+
 static int has_ext(const char *ext) {
     const char *terminator;
     const char *loc;

--- a/glad/lang/c/loader/wgl.py
+++ b/glad/lang/c/loader/wgl.py
@@ -64,6 +64,9 @@ _WGL_HEADER_END = '''
 _WGL_HAS_EXT = '''
 static HDC GLADWGLhdc = (HDC)INVALID_HANDLE_VALUE;
 
+static void get_exts(void) {
+}
+
 static int has_ext(const char *ext) {
     const char *terminator;
     const char *loc;


### PR DESCRIPTION
Invoke `glGetString(GL_EXTENSIONS)` only once (instead of
GL_NUM_EXTENSIONS), and `glGetStringi(GL_EXTENSIONS)` only
GL_NUM_EXTENSIONS (instead of roughly
GL_NUM_EXTENSIONS*GL_NUM_EXTENSIONS).

This is particularly handy when obtaining traces of applications that
use GLAD, which otherwise get over 10K of redundant calls nowadays
(and probably much more in the future).