### PR TITLE
cmake: fix typo in GLAD_SOURCES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if (NOT GLAD_GENERATOR)
 endif()
 
 set(GLAD_INCLUDE_DIRS "${GLAD_OUT_DIR}/include")
-set(GLAD_SOURCES "${GLAD_OUT_DIR}/src/glad.c" "${GLAD_INCLUDE_DIRS}/glad.h")
+set(GLAD_SOURCES "${GLAD_OUT_DIR}/src/glad.c" "${GLAD_INCLUDE_DIRS}/glad/glad.h")
 message("GLAD_SOURCES ${GLAD_SOURCES}")
 include_directories(${GLAD_INCLUDE_DIRS})
 add_custom_command(


### PR DESCRIPTION
The path to the glad header is incorrect, causing the custom command to regenerate the source files on every build. This simply fixes the path, so that the command only generates the sources when they are missing.