### PR TITLE
Correct the placement of call-convention specifier

### DIFF
--- a/glad/lang/c/debug.py
+++ b/glad/lang/c/debug.py
@@ -77,7 +77,7 @@ class CDebugGenerator(CGenerator):
         fobj.write('#define {0} glad_debug_{0}\n'.format(func.proto.name))
 
     def write_function(self, fobj, func):
-        fobj.write('APIENTRY PFN{}PROC glad_{};\n'.format(
+        fobj.write('PFN{}PROC glad_{};\n'.format(
             func.proto.name.upper(), func.proto.name
         ))
 
@@ -86,7 +86,7 @@ class CDebugGenerator(CGenerator):
             '{type} arg{i}'.format(type=param.type.to_c(), i=i)
             for i, param in enumerate(func.params)
         )
-        fobj.write('APIENTRY {} glad_debug_impl_{}({}) {{'.format(
+        fobj.write('{} APIENTRY glad_debug_impl_{}({}) {{'.format(
             func.proto.ret.to_c(), func.proto.name, args_def
         ))
         args = ', '.join('arg{}'.format(i) for i, _ in enumerate(func.params))


### PR DESCRIPTION
No-one seems to have labelled this as a bug, but on Visual Studio code generated with the `c-debug` generator fails to compile. I've tracked this down to the substitution of `APIENTRY` to `__stdcall`.

This means that the calling convention is specified in the wrong place? Swapping the placement of the type-specifier, and the call convention fixes this. Function pointers also already have theirs specified in their `typedef`.

The `c-debug` generator results now correctly compile for me on Visual Studio 2013.