### PR TITLE
c: Fix a directive of GLVersion for access in DLL.

### DIFF
--- a/glad/lang/c/loader/gl.py
+++ b/glad/lang/c/loader/gl.py
@@ -133,10 +133,10 @@ struct gladGLversionStruct {
     int minor;
 };
 
-extern struct gladGLversionStruct GLVersion;
-
 typedef void* (* GLADloadproc)(const char *name);
-''' + LOAD_OPENGL_GLAPI_H
+''' + LOAD_OPENGL_GLAPI_H + '''
+GLAPI struct gladGLversionStruct GLVersion;
+'''
 
 _OPENGL_HEADER_LOADER = '''
 GLAPI int gladLoadGL(void);


### PR DESCRIPTION
When C DLL version is used, GLVersion variable cannot be accessed because of omitting export. I changed "extern" to "GLAPI" and moved the statement to the next of API generation.