### PR TITLE
Fix running GLAD locally with pip installed.

### DIFF
--- a/glad/util.py
+++ b/glad/util.py
@@ -19,5 +19,7 @@ def get_glad_version():
         import pkg_resources
     except ImportError:
         return 'Unknown'
-
-    return pkg_resources.get_distribution('glad').version
+    try:
+        return pkg_resources.get_distribution('glad').version
+    except pkg_resources.DistributionNotFound:
+        return 'Unknown'


### PR DESCRIPTION
I use GLAD as ExternalProject_Add CMake dependency and ran into an issue in environments,
where pip is available but glad is not installed, because pkg_resources is available, but raises an exception.