### PR TITLE
Fix the handling of the --no-loader flag

### DIFF
--- a/glad/lang/common/generator.py
+++ b/glad/lang/common/generator.py
@@ -53,7 +53,7 @@ class Generator(object):
         self.api = api
         self.extension_names = extension_names
 
-        self.has_loader = loader is None
+        self.has_loader = not loader.disabled
         self.loader = loader
         if self.loader is None:
             self.loader = NullLoader


### PR DESCRIPTION
Without this fix `Loader: No` will always appear in the file comments of the generated files.