### PR TITLE
Improve the C generator to especially better support for the Windows platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ Possible commandline options:
       --spec {gl,egl,glx,wgl}
                             Name of the spec
       --no-loader
+      --omit-khrplatform    Omits inclusion of the khrplatform.h file which is
+                            often unnecessary. Only has an effect if used
+                            together with c generators.
+      --local-files         Forces every file directly into the output directory.
+                            No src or include subdirectories are generated. Only
+                            has an effect if used together with c generators.
 
 
 To generate a loader for C with two extensions, it could look like this:

--- a/glad/__main__.py
+++ b/glad/__main__.py
@@ -103,6 +103,17 @@ def main():
                         choices=['gl', 'egl', 'glx', 'wgl'],
                         help='Name of the spec')
     parser.add_argument('--no-loader', dest='no_loader', action='store_true')
+    parser.add_argument('--omit-khrplatform', dest='omit_khrplatform', action='store_true',
+                        help='Omits inclusion of the khrplatform.h '
+                        'file which is often unnecessary. '
+                        'Only has an effect if used together '
+                        'with c generators.')
+    parser.add_argument('--local-files', dest='local_files', action='store_true',
+                        help='Forces every file directly into the output '
+                        'directory. No src or include subdirectories '
+                        'are generated. '
+                        'Only has an effect if used together '
+                        'with c generators.')
     parser.add_argument('--quiet', dest='quiet', action='store_true')
 
     ns = parser.parse_args()
@@ -125,11 +136,15 @@ def main():
         ns.generator, spec.NAME.lower()
     )
 
+    generator_cls.local_files = ns.local_files
+    generator_cls.omit_khrplatform = ns.omit_khrplatform
+
     if loader_cls is None:
         return parser.error('API/Spec not yet supported')
 
     loader = loader_cls(api)
     loader.disabled = ns.no_loader
+    loader.local_files = ns.local_files
 
     logger.info('generating \'%s\' bindings', spec.NAME)
     with generator_cls(ns.out, spec, api, ns.extensions, loader=loader, opener=opener) as generator:

--- a/glad/lang/c/loader/__init__.py
+++ b/glad/lang/c/loader/__init__.py
@@ -11,7 +11,7 @@ PFNWGLGETPROCADDRESSPROC_PRIVATE gladGetProcAddressPtr;
 
 %(pre)s
 int %(init)s(void) {
-    libGL = LoadLibraryA("opengl32.dll");
+    libGL = LoadLibraryW(L"opengl32.dll");
     if(libGL != NULL) {
         gladGetProcAddressPtr = (PFNWGLGETPROCADDRESSPROC_PRIVATE)GetProcAddress(
                 libGL, "wglGetProcAddress");

--- a/glad/lang/c/loader/glx.py
+++ b/glad/lang/c/loader/glx.py
@@ -16,12 +16,15 @@ int gladLoadGLX(Display *dpy, int screen) {
 }
 '''
 
-_GLX_HEADER = '''
+_GLX_HEADER_START = '''
 #include <X11/X.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
+'''
+
 #include <glad/glad.h>
 
+_WGL_HEADER_MID = '''
 #ifndef __glad_glxext_h_
 
 #ifdef __glxext_h_
@@ -131,7 +134,12 @@ class GLXCLoader(BaseLoader):
         fobj.write(_GLX_HAS_EXT)
 
     def write_header(self, fobj):
-        fobj.write(_GLX_HEADER)
+        fobj.write(_GLX_HEADER_START)
+        if self.local_files:
+            fobj.write('#include "glad.h"\n')
+        else:
+            fobj.write('#include <glad/glad.h>\n')
+        fobj.write(_WGL_HEADER_MID)
         if not self.disabled:
             fobj.write(_GLX_HEADER_LOADER)
 

--- a/glad/lang/c/loader/wgl.py
+++ b/glad/lang/c/loader/wgl.py
@@ -16,7 +16,7 @@ int gladLoadWGL(HDC hdc) {
 }
 '''
 
-_WGL_HEADER = '''
+_WGL_HEADER_START = '''
 #ifndef WINAPI
 # ifndef WIN32_LEAN_AND_MEAN
 #  define WIN32_LEAN_AND_MEAN 1
@@ -24,8 +24,11 @@ _WGL_HEADER = '''
 # include <windows.h>
 #endif
 
+'''
+
 #include <glad/glad.h>
 
+_WGL_HEADER_MID = '''
 #ifndef __glad_wglext_h_
 
 #ifdef __wglext_h_
@@ -126,7 +129,12 @@ class WGLCLoader(BaseLoader):
         fobj.write(_WGL_HAS_EXT)
 
     def write_header(self, fobj):
-        fobj.write(_WGL_HEADER)
+        fobj.write(_WGL_HEADER_START)
+        if self.local_files:
+            fobj.write('#include "glad.h"\n')
+        else:
+            fobj.write('#include <glad/glad.h>\n')
+        fobj.write(_WGL_HEADER_MID)
         if not self.disabled:
             fobj.write(_WGL_HEADER_LOADER)
 

--- a/glad/lang/common/loader.py
+++ b/glad/lang/common/loader.py
@@ -1,7 +1,8 @@
 class BaseLoader(object):
-    def __init__(self, apis, disabled=False):
+    def __init__(self, apis, disabled=False, local_files=False):
         self.apis = apis
         self.disabled = disabled
+        self.local_files = local_files
 
     def write(self, fobj):
         raise NotImplementedError


### PR DESCRIPTION
Basicly I have made 3 changes to improve the usage of the C generator especially on Windows:
- `--local-files`: This command line option informs Glad to put all files into a single directory. Inside the MSVC environment it is uncommon to split files into seperate directories for headers and sources. Additionally it is no longer necessary to add the Glad header directory to the include paths which is much more convenient.
- `--omit-khrplatform`: This option prevents the often unnecessary file `khrplatform.h` from getting downloaded and included.
- I changed `LoadLibraryA` to `LoadLibraryW` since the usage of the old Ansi functions is generally not recommended anymore.

It would propably make sense to add some of these options to other generators but this is outside the scope of this pull request.

Note: I am not familiar with Python programming. If there is anything that could be improved, I would be happy to change it.