### PR TITLE
cmake: allow cmake to use primary python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@ project(GLAD)
 
 set(GLAD_DIR "${PROJECT_SOURCE_DIR}")
 set(GLAD_OUT_DIR "${PROJECT_BINARY_DIR}")
-set(Python_ADDITIONAL_VERSIONS 2)
 find_package(PythonInterp REQUIRED)
 
 # Options


### PR DESCRIPTION
In CMakeLists.txt, this seems unnecessary:

`set(Python_ADDITIONAL_VERSIONS 2)`

Using pyenv where both python 2 and python 3 are present, but where python 3 is the default python in use, this line seems to make cmake favour python 2, resulting in failure to find python.