### PR TITLE
d: change deprecated imports to non-deprecated ones for windows api

### DIFF
--- a/glad/lang/d/generator.py
+++ b/glad/lang/d/generator.py
@@ -41,7 +41,7 @@ def _egl_types(gen, f):
     f.write('''
 // Thanks to @jpf91 (github) for these declarations
 version(Windows) {
-    import std.c.windows.windows;
+    import core.sys.windows.windows;
     alias EGLNativeDisplayType = HDC;
     alias EGLNativePixmapType = HBITMAP;
     alias EGLNativeWindowType = HWND;

--- a/glad/lang/d/loader/__init__.py
+++ b/glad/lang/d/loader/__init__.py
@@ -1,7 +1,7 @@
 
 LOAD_OPENGL_DLL = '''
 version(Windows) {
-    private import std.c.windows.windows;
+    private import core.sys.windows.windows;
 } else {
     private import core.sys.posix.dlfcn;
 }


### PR DESCRIPTION
Old import was still there in two places, the deprecation messages were bothering me a bit so I decided to make a PR. It's used in other places in the code already too, so it *should* be fine.