### PR TITLE
added support for cmake install, and to disable parent scope variables.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ set(GLAD_GENERATOR "c" CACHE STRING "Language to generate the binding for")
 set(GLAD_EXTENSIONS "" CACHE STRING "Path to extensions file or comma separated list of extensions, if missing all extensions are included")
 set(GLAD_SPEC "gl" CACHE STRING "Name of the spec")
 set(GLAD_NO_LOADER OFF CACHE BOOL "No loader")
+set(GLAD_EXPORT ON CACHE BOOL "Set export variables for external project")
+set(GLAD_INSTALL OFF CACHE BOOL "Generate installation target")
 
 if(GLAD_GENERATOR STREQUAL "d")
   list(APPEND GLAD_SOURCES
@@ -68,5 +70,16 @@ if(GLAD_LINKER_LANGUAGE)
 endif()
 
 # Export
-set(GLAD_LIBRARIES glad PARENT_SCOPE)
-set(GLAD_INCLUDE_DIRS ${GLAD_INCLUDE_DIRS} PARENT_SCOPE)
+if(GLAD_EXPORT)
+  set(GLAD_LIBRARIES glad PARENT_SCOPE)
+  set(GLAD_INCLUDE_DIRS ${GLAD_INCLUDE_DIRS} PARENT_SCOPE)
+endif()
+
+# Install
+if(GLAD_INSTALL)
+  if(GLAD_INCLUDE_DIRS)
+    install(DIRECTORY ${GLAD_INCLUDE_DIRS} DESTINATION ${CMAKE_INSTALL_PREFIX})
+  endif()
+  install(TARGETS glad EXPORT glad-targets
+          ARCHIVE DESTINATION lib)
+endif()


### PR DESCRIPTION
Default behaviour is still the same, but added option to enable generation of install targets (GLAD_INSTALL). Also, when generating solution on its own cmake was complaining that there was no parent scope so also added option to disable export (GLAD_EXPORT).

Can be tested by using `-D GLAD_INSTAL:BOOL=ON` and optionally `-D GLAD_EXPORT:BOOL=OFF` when generating solution, which will create the install target as well.

This allows the library to be installed at default location, or at custom location by setting variable `CMAKE_INSTALL_PREFIX`. Also, and perhaps most importantly, this allows the library to be include in cmake projects using [ExternalProject_Add](https://cmake.org/cmake/help/v3.0/module/ExternalProject.html) linking the release source, or git branch/tag/commit directly. No need to manually download or install anything.

I haven't been able to test for the D or Volt generators, so can we confirm that that hasn't broken down?

PS. First pull request so perhaps not entirely according to standard approach, sorry.
