### PR TITLE
gl: remove unnecessary cast

### DIFF
--- a/glad/lang/c/loader/gl.py
+++ b/glad/lang/c/loader/gl.py
@@ -60,7 +60,7 @@ static int get_exts(void) {
 
 static void free_exts(void) {
     if (exts_i != NULL) {
-        free((char **)exts_i);
+        free(exts_i);
         exts_i = NULL;
     }
 }


### PR DESCRIPTION
Removes warning:

> src/glad.c:177:23: error: cast from type ‘const char**’ to type ‘char**’ casts away qualifiers [-Werror=cast-qual]

AFAIK,  I don't think this cast is necessary anyway?