### PR TITLE
Fix the const warning for the compiler

### DIFF
--- a/glad/lang/c/loader/gl.py
+++ b/glad/lang/c/loader/gl.py
@@ -60,7 +60,7 @@ static int get_exts(void) {
 
 static void free_exts(void) {
     if (exts_i != NULL) {
-        free(exts_i);
+        free((void *)exts_i);
         exts_i = NULL;
     }
 }


### PR DESCRIPTION
Fix the compiler wrong when try to free the const type.