### PR TITLE
Added EGL runtime extension flags support

### DIFF
--- a/glad/lang/c/loader/egl.py
+++ b/glad/lang/c/loader/egl.py
@@ -2,8 +2,8 @@ from glad.lang.common.loader import BaseLoader
 
 
 _EGL_LOADER = '''
-int gladLoadEGL(void) {
-    return gladLoadEGLLoader((GLADloadproc)eglGetProcAddress);
+int gladLoadEGL(EGLDisplay display) {
+    return gladLoadEGLLoader((GLADloadproc)eglGetProcAddress, display);
 }
 '''
 
@@ -39,10 +39,11 @@ extern "C" {
 #endif
 
 typedef void* (* GLADloadproc)(const char *name);
+typedef void* EGLDisplay;
 '''
 
 _EGL_HEADER_LOADER = '''
-GLAPI int gladLoadEGL(void);
+GLAPI int gladLoadEGL(EGLDisplay display);
 '''
 
 _EGL_HEADER_END = '''
@@ -54,6 +55,24 @@ _EGL_HEADER_END = '''
 '''
 
 _EGL_HAS_EXT = '''
+static const char *exts = NULL;
+
+static int get_exts(EGLDisplay display) {
+  exts = eglQueryString(display, EGL_EXTENSIONS);
+  return 1;
+}
+
+static void free_exts(void) {
+  /* NOTE: currently nothing allocated for EGL extensions */
+  exts = NULL;
+}
+
+static int has_ext(const char *ext) {
+  if (exts != NULL && ext != NULL) {
+    return (strstr(exts, ext) != NULL) ? 1 : 0;
+  }
+  return 0;
+}
 '''
 
 


### PR DESCRIPTION
I had some spare time today to look at issue #96 a bit. I'm not terribly familiar with the project so I'm not sure if this was the best approach but it does seem to work -- at least in an EGL project of mine.

The tricky thing was that in EGL you need an EGLDisplay if you want to get the list of extensions. So I had to augment the generated loaders to require the user to pass the display. Below is an example of its use:

```cpp
EGLDisplay display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
eglInitialize(display, 0, 0);

if (!gladLoadEGL(display)) {
  fprintf(stderr, "Unable to load EGL via GLAD!\n");
  return;
}

printf("EGL_KHR_get_all_proc_addresses? %d\n", GLAD_EGL_KHR_get_all_proc_addresses);
printf("EGL_KHR_swap_buffers_with_damage? %d\n", GLAD_EGL_KHR_swap_buffers_with_damage);
printf("EGL_KHR_gl_colorspace (build support)? %d\n", EGL_KHR_gl_colorspace);
printf("EGL_KHR_gl_colorspace (runtime support)? %d\n", GLAD_EGL_KHR_gl_colorspace);
```

And this is the command I used to generate the stubs:

    $ python3 -m glad --out-path /tmp/glad --api 'egl=1.4' --generator c --spec egl

Thanks