### PR TITLE
CMake: Fix a missing GLAD_GLAPI_EXPORT when building the shared variant

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,13 @@ add_library(glad ${GLAD_SOURCES})
 add_dependencies(glad glad-generate-files)
 target_include_directories(glad PUBLIC ${GLAD_INCLUDE_DIRS})
 
+# Are we building a shared library?
+get_target_property(library_type glad TYPE)
+if (library_type STREQUAL SHARED_LIBRARY)
+  # If so, define the macro GLAD_API_EXPORT on the command line.
+  target_compile_definitions(glad PRIVATE GLAD_GLAPI_EXPORT)
+endif()
+
 if(GLAD_LINKER_LANGUAGE)
   set_target_properties(glad PROPERTIES LINKER_LANGUAGE ${GLAD_LINKER_LANGUAGE})
 endif()


### PR DESCRIPTION
When building a shared version of the library, the macro `GLAD_GLAPI_EXPORT` must be defined on the command line in order to actually export all of the functions. This is taken of now.