### PR TITLE
cmake : Add library destination.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,5 +88,6 @@ if(GLAD_INSTALL)
     install(DIRECTORY ${GLAD_INCLUDE_DIRS} DESTINATION ${CMAKE_INSTALL_PREFIX})
   endif()
   install(TARGETS glad EXPORT glad-targets
-          ARCHIVE DESTINATION lib)
+          ARCHIVE DESTINATION lib
+          LIBRARY DESTINATION lib)
 endif()


### PR DESCRIPTION
Fixes a cmake error when building in shared mode.
```
install TARGETS given no LIBRARY DESTINATION for shared library target
```