### PR TITLE
Remove const from exts_i variable to avoid -Wcast-qual warnings

### DIFF
--- a/glad/lang/c/loader/gl.py
+++ b/glad/lang/c/loader/gl.py
@@ -29,7 +29,7 @@ static int max_loaded_minor;
 
 static const char *exts = NULL;
 static int num_exts_i = 0;
-static const char **exts_i = NULL;
+static char **exts_i = NULL;
 
 static int get_exts(void) {
 #ifdef _GLAD_IS_SOME_NEW_VERSION
@@ -43,7 +43,7 @@ static int get_exts(void) {
         num_exts_i = 0;
         glGetIntegerv(GL_NUM_EXTENSIONS, &num_exts_i);
         if (num_exts_i > 0) {
-            exts_i = (const char **)realloc((void *)exts_i, (size_t)num_exts_i * (sizeof *exts_i));
+            exts_i = (char **)realloc((void *)exts_i, (size_t)num_exts_i * (sizeof *exts_i));
         }
 
         if (exts_i == NULL) {


### PR DESCRIPTION
With `-Wcast-qual` enabled, glad.c gives the following warning:

```
source/glad/src/glad.c: In function 'void free_exts()':
source/glad/src/glad.c:202:38: warning: cast from type 'const char*' to type 'char*' casts away qualifiers [-Wcast-qual]
             free((char *)exts_i[index]);
                                      ^
```

Upon inspection, this variable is filled with an allocation on the heap, which suggests its type should not point to const data.