### PR TITLE
Work-around for the pedantic warning in the loader

### DIFF
--- a/glad/lang/c/generator.py
+++ b/glad/lang/c/generator.py
@@ -72,7 +72,7 @@ class CGenerator(Generator):
                 if self.spec.NAME in ('gl', 'glx', 'wgl'):
                     f.write('\tif(!GLAD_{}) return;\n'.format(feature.name))
                 for func in feature.functions:
-                    f.write('\tglad_{0} = (PFN{1}PROC)load("{0}");\n'
+                    f.write('\t*(void**) (&glad_{0}) = load("{0}");\n'
                             .format(func.proto.name, func.proto.name.upper()))
                 f.write('}\n')
 
@@ -88,7 +88,7 @@ class CGenerator(Generator):
                 if ext.name == 'GLX_SGIX_dmbuffer': f.write('#ifdef _DM_BUFFER_H_\n')
                 for func in ext.functions:
                     # even if they were in written we need to load it
-                    f.write('\tglad_{0} = (PFN{1}PROC)load("{0}");\n'
+                    f.write('\t*(void**)glad_{0} = load("{0}");\n'
                             .format(func.proto.name, func.proto.name.upper()))
                 if ext.name in ('GLX_SGIX_video_source', 'GLX_SGIX_dmbuffer'):
                     f.write('#else\n')

--- a/glad/lang/c/loader/__init__.py
+++ b/glad/lang/c/loader/__init__.py
@@ -77,7 +77,7 @@ int %(init)s(void) {
 #ifdef __APPLE__
             return 1;
 #else
-            gladGetProcAddressPtr = (PFNGLXGETPROCADDRESSPROC_PRIVATE)dlsym(libGL,
+            *(void**) (&gladGetProcAddressPtr) = dlsym(libGL,
                 "glXGetProcAddressARB");
             return gladGetProcAddressPtr != NULL;
 #endif

--- a/glad/lang/c/loader/gl.py
+++ b/glad/lang/c/loader/gl.py
@@ -225,7 +225,7 @@ class OpenGLCLoader(BaseLoader):
 
     def write_begin_load(self, fobj):
         fobj.write('\tGLVersion.major = 0; GLVersion.minor = 0;\n')
-        fobj.write('\tglGetString = (PFNGLGETSTRINGPROC)load("glGetString");\n')
+        fobj.write('\t*(void**) (&glGetString) = load("glGetString");\n')
         fobj.write('\tif(glGetString == NULL) return 0;\n')
         fobj.write('\tif(glGetString(GL_VERSION) == NULL) return 0;\n')
 


### PR DESCRIPTION
Implements the fix suggested in https://stackoverflow.com/questions/14134245/iso-c-void-and-function-pointers

Closes #44 
