### PR TITLE
Add `type` field to the `Enum` class

### DIFF
--- a/glad/parse.py
+++ b/glad/parse.py
@@ -750,7 +750,7 @@ class Enum(IdentifiedByName):
     EXTENSION_NUMBER_MULTIPLIER = 1000
     EXTENSION_NUMBER_OFFSET = -1
 
-    def __init__(self, name, value, bitpos, api,
+    def __init__(self, name, value, bitpos, api, type_,
                  alias=None, namespace=None, group=None, vendor=None,
                  comment='', extended_by=None):
         self.name = name
@@ -759,6 +759,7 @@ class Enum(IdentifiedByName):
             self.value = 1 << int(bitpos)
         self.bitpos = bitpos
         self.api = api
+        self.type = type_
 
         self.alias = alias
 
@@ -779,7 +780,7 @@ class Enum(IdentifiedByName):
         return self.name
 
     def __repr__(self):
-        return 'Enum(name={self.name}, value={self.value})'.format(self=self)
+        return 'Enum(name={self.name}, value={self.value}, type={self.type})'.format(self=self)
 
     @classmethod
     def from_element(cls, element, extnumber=None, **kwargs):
@@ -787,6 +788,7 @@ class Enum(IdentifiedByName):
         value = element.get('value')
         bitpos = element.get('bitpos')
         api = element.get('api')
+        type_ = element.get('type')
 
         alias = element.get('alias')
 
@@ -803,7 +805,7 @@ class Enum(IdentifiedByName):
             if element.get('dir') == '-':
                 value = -value
 
-        return cls(name, value, bitpos, api, alias=alias, **kwargs)
+        return cls(name, value, bitpos, api, type_, alias=alias, **kwargs)
 
 
 class Command(IdentifiedByName):


### PR DESCRIPTION
There is a `type` attribute on some enums, specifically: `GL_INVALID_INDEX` ("u"), `GL_TIMEOUT_IGNORED` and `GL_TIMEOUT_IGNORED_APPLE` ("ull"). Documentation avaliable [here](https://github.com/KhronosGroup/OpenGL-Registry/blob/master/xml/readme.pdf), on page 9, section 9.1