### PR TITLE
Fix khr_url on Windows

### DIFF
--- a/glad/lang/c/generator.py
+++ b/glad/lang/c/generator.py
@@ -53,7 +53,7 @@ class CGenerator(Generator):
         if not self.omit_khrplatform:
             khr_url = KHRPLATFORM
             if os.path.exists('khrplatform.h'):
-                khr_url = 'file://' + os.path.abspath('khrplatform.h')
+                khr_url = 'file:///' + os.path.abspath('khrplatform.h')
 
             khrplatform = os.path.join(khr, 'khrplatform.h')
             if not os.path.exists(khrplatform):


### PR DESCRIPTION
If `khrplatform.h` is already downloaded to the root directory of glad then the `khr_url` is incorrect on Windows. It will be set to `file://c:\glad\khrplatform.h` when it should be `file:///c:\glad\khrplatform.h` (notice 3 slashes).

How to reproduce the issue:
* Download https://raw.githubusercontent.com/KhronosGroup/EGL-Registry/master/api/KHR/khrplatform.h to the root directory of glad
* Create `tmp` directory
* Run `python -m glad --generator c --out-path tmp`

This issue is present on both Python 2.7 (`IOError: [Errno socket error] [Errno 11001] getaddrinfo failed`) and Python 3.6 (`urllib.error.URLError: <urlopen error [WinError 3] The system cannot find the path specified: ''>`).

Changing [khr_url](https://github.com/Dav1dde/glad/blob/master/glad/lang/c/generator.py#L56) to `file:///` seems to fix the issue on Windows and Linux seems to also accept the url in this format.