### PR TITLE
treat extensions with empty string as None to fix build using CMake

### DIFF
--- a/glad/__main__.py
+++ b/glad/__main__.py
@@ -132,6 +132,8 @@ def main():
         ns.generator, spec.NAME.lower()
     )
 
+    extensions = ns.extensions if ns.extensions else None
+
     if loader_cls is None:
         return parser.error('API/Spec not yet supported')
 
@@ -142,7 +144,7 @@ def main():
             ns.out,
             spec,
             api,
-            ns.extensions,
+            extensions,
             loader=loader,
             opener=opener,
             local_files=ns.local_files,


### PR DESCRIPTION
I am trying build using CMake and it should be create with all extensions when extensions is empty.