### PR TITLE
c: sort enums, extensions and function pointers

### DIFF
--- a/glad/generator/__init__.py
+++ b/glad/generator/__init__.py
@@ -127,11 +127,15 @@ class JinjaGenerator(BaseGenerator):
         Even though it is possible to return a new feature set,
         such modifications should rather be done in `select`.
 
-        Default implementation does nothing.
+        Default implementation sorts.
 
         :param feature_set: feature set to modify (the one passed to `get_templates`)
         :return: modified feature set
         """
+        feature_set.commands = sorted(list(feature_set.commands), key=lambda x: x.name)
+        feature_set.enums = sorted(list(feature_set.enums), key=lambda x: x.name)
+        feature_set.extensions.sort(key=lambda x: x.name)
+
         return feature_set
 
     def get_template_arguments(self, spec, feature_set, config):

--- a/glad/generator/c/__init__.py
+++ b/glad/generator/c/__init__.py
@@ -359,6 +359,8 @@ class CGenerator(JinjaGenerator):
         # TODO this takes rather lonng (~30%), maybe drop it?
         feature_set = copy.deepcopy(feature_set)
 
+        feature_set = JinjaGenerator.modify_feature_set(self, spec, feature_set, config)
+
         self._fix_issue_70(feature_set)
         self._fix_cpp_style_comments(feature_set)
         self._replace_included_headers(feature_set, config)

--- a/glad/parse.py
+++ b/glad/parse.py
@@ -1033,12 +1033,16 @@ class Extension(IdentifiedByName):
         types, enums, commands = spec.split_types(result, (Type, Enum, Command))
 
         if feature_set is None:
-            return TypeEnumCommand(types, enums, commands)
+            return TypeEnumCommand(
+                sorted(types, key=lambda x: x.name),
+                sorted(enums, key=lambda x: x.name),
+                sorted(commands, key=lambda x: x.name),
+            )
 
         return TypeEnumCommand(
-            types.intersection(feature_set.types),
-            enums.intersection(feature_set.enums),
-            commands.intersection(feature_set.commands)
+            sorted(list(types.intersection(feature_set.types)), key=lambda x: x.name),
+            sorted(list(enums.intersection(feature_set.enums)), key=lambda x: x.name),
+            sorted(list(commands.intersection(feature_set.commands)), key=lambda x: x.name),
         )
 
     def __str__(self):


### PR DESCRIPTION
Same as #163 but for the `glad2` branch.

Fixes #162