### PR TITLE
Fix MSVC static analysis warning on realloc

### DIFF
--- a/glad/lang/c/loader/gl.py
+++ b/glad/lang/c/loader/gl.py
@@ -43,7 +43,8 @@ static int get_exts(void) {
         num_exts_i = 0;
         glGetIntegerv(GL_NUM_EXTENSIONS, &num_exts_i);
         if (num_exts_i > 0) {
-            exts_i = (char **)realloc((void *)exts_i, (size_t)num_exts_i * (sizeof *exts_i));
+            char **tmp_exts_i = (char **)realloc((void *)exts_i, (size_t)num_exts_i * (sizeof *exts_i));
+            exts_i = tmp_exts_i;
         }
 
         if (exts_i == NULL) {


### PR DESCRIPTION
Using Microsoft (R) C/C++ Optimizing Compiler Version 19.15.26730 for x64
with the `/analyze` flag for static analysis, a warning is issued:

glad.c(777) : warning C6308: 'realloc' might return null pointer: assigning null pointer to 'exts_i', which is passed as an argument to 'realloc', will cause the original memory block to be leaked.

This change avoids the warning.