### PR TITLE
Fix C generator crash without python setuptools

### DIFF
--- a/glad/lang/c/generator.py
+++ b/glad/lang/c/generator.py
@@ -62,7 +62,7 @@ class CGenerator(Generator):
                     os.makedirs(khr)
 
                 if self.options.get('reproducible', False):
-                    with glad.files.open_local('khrplatform.h') as src:
+                    with glad.files.open_local('khrplatform.h', 'rb') as src:
                         with open(khrplatform, 'wb') as dst:
                             dst.write(src.read())
                 else:


### PR DESCRIPTION
In reproducible mode, the following is happening:

```
[root@41dad9bc2d15 build]# cmake -GNinja -DGLAD_REPRODUCIBLE=ON .. && ninja
-- The C compiler identification is GNU 8.2.1
-- Check for working C compiler: /usr/sbin/cc
-- Check for working C compiler: /usr/sbin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Found PythonInterp: /usr/sbin/python (found version "3.7.2") 
-- Configuring done
-- Generating done
-- Build files have been written to: /root/glad/build
[1/3] Generating GLAD
FAILED: src/glad.c include/glad/glad.h 
cd /root/glad && /usr/sbin/python -m glad --profile=compatibility --out-path=/root/glad/build --api= --generator=c --extensions= --spec=gl --reproducible
[02/02/2019 15:44:45][INFO	][glad   	]: reproducible build, using packaged specification: 'gl.xml'
[02/02/2019 15:44:45][INFO	][glad.files	]: opening 'gl.xml' from packaged path
[02/02/2019 15:44:46][INFO	][glad   	]: generating 'gl' bindings
[02/02/2019 15:44:46][INFO	][glad.files	]: opening 'khrplatform.h' from packaged path
Traceback (most recent call last):
  File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/root/glad/glad/__main__.py", line 174, in <module>
    main()
  File "/root/glad/glad/__main__.py", line 167, in main
    reproducible=ns.reproducible
  File "/root/glad/glad/lang/common/generator.py", line 83, in __enter__
    self.open()
  File "/root/glad/glad/lang/c/generator.py", line 67, in open
    dst.write(src.read())
TypeError: a bytes-like object is required, not 'str'
ninja: build stopped: subcommand failed.
```