### PR TITLE
Added support for a macro disabling the windows header

### DIFF
--- a/glad/lang/c/loader/gl.py
+++ b/glad/lang/c/loader/gl.py
@@ -134,13 +134,23 @@ _OPENGL_HEADER_INCLUDE_ERROR = '''
 
 _OPENGL_HEADER = '''
 #if defined(_WIN32) && !defined(APIENTRY) && !defined(__CYGWIN__) && !defined(__SCITECH_SNAP__)
+
+#ifdef GLAD_NO_INCLUDE_WINDOWS
+#define APIENTRY __stdcall
+
+#else
+
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN 1
 #endif
 #ifndef NOMINMAX
 #define NOMINMAX 1
 #endif
+
 #include <windows.h>
+
+#endif
+
 #endif
 
 #ifndef APIENTRY


### PR DESCRIPTION
Users can define `GLAD_NO_INCLUDE_WINDOWS` before including glad.h in order to disable the Windows header from being included at all. If this macro is not present, behavior is unchanged, `Windows.h` is included with `WIN32_LEAN_AND_MEAN` and `NOMINMAX`.