### PR TITLE
obtaining EGL/eglplatform.h from a more reliable source

### DIFF
--- a/glad/generator/c/__init__.py
+++ b/glad/generator/c/__init__.py
@@ -185,7 +185,7 @@ class CGenerator(JinjaGenerator):
         Header(
             'eglplatform',
             'EGL/eglplatform.h',
-            'https://cgit.freedesktop.org/mesa/mesa/plain/include/EGL/eglplatform.h'
+            'https://www.khronos.org/registry/EGL/api/EGL/eglplatform.h'
         ),
         Header(
             'vk_platform',

--- a/utility/compiletest.sh
+++ b/utility/compiletest.sh
@@ -58,7 +58,7 @@ function download_if_required {
 echo -e "====================== Generating and compiling C/C++: ======================"
 
 rm -rf build
-download_if_required build/include/EGL/eglplatform.h "https://cgit.freedesktop.org/mesa/mesa/plain/include/EGL/eglplatform.h"
+download_if_required build/include/EGL/eglplatform.h "https://www.khronos.org/registry/EGL/api/EGL/eglplatform.h"
 download_if_required build/include/KHR/khrplatform.h "https://raw.githubusercontent.com/KhronosGroup/EGL-Registry/master/api/KHR/khrplatform.h"
 ${PYTHON} -m glad --api="egl" --out-path=build c
 c_compile -Ibuild/include build/src/egl.c ${GCC_FLAGS}
@@ -102,7 +102,7 @@ mingwcpp_compile -Ibuild/include build/src/wgl.c ${GPP_FLAGS}
 echo -e "====================== Generating and compiling C/C++ Debug: ======================"
 
 rm -rf build
-download_if_required build/include/EGL/eglplatform.h "https://cgit.freedesktop.org/mesa/mesa/plain/include/EGL/eglplatform.h"
+download_if_required build/include/EGL/eglplatform.h "https://www.khronos.org/registry/EGL/api/EGL/eglplatform.h"
 download_if_required build/include/KHR/khrplatform.h "https://raw.githubusercontent.com/KhronosGroup/EGL-Registry/master/api/KHR/khrplatform.h"
 ${PYTHON} -m glad --api="egl" --out-path=build c --debug
 c_compile -Ibuild/include build/src/egl.c ${GCC_FLAGS}

--- a/utility/download.sh
+++ b/utility/download.sh
@@ -25,7 +25,7 @@ rm -f "${TARGET}/khrplatform.h"
 wget -O "${TARGET}/khrplatform.h" https://raw.githubusercontent.com/KhronosGroup/EGL-Registry/master/api/KHR/khrplatform.h
 
 rm -f "${TARGET}/eglplatform.h"
-wget -O "${TARGET}/eglplatform.h" https://cgit.freedesktop.org/mesa/mesa/plain/include/EGL/eglplatform.h
+wget -O "${TARGET}/eglplatform.h" https://www.khronos.org/registry/EGL/api/EGL/eglplatform.h
 
 rm -f "${TARGET}/vk_platform.h"
 wget -O "${TARGET}/vk_platform.h" https://raw.githubusercontent.com/KhronosGroup/Vulkan-Docs/master/include/vulkan/vk_platform.h


### PR DESCRIPTION
in case nobody noticed, generating EGL from Glad2's web service (https://gen.glad.sh) gives us 504 Gateway Time-out. I deduced that the cause of this time out is from this link which also times out:

https://cgit.freedesktop.org/mesa/mesa/plain/include/EGL/eglplatform.h

I changed it to a more reliable and accurate source: https://www.khronos.org/registry/EGL/api/EGL/eglplatform.h

and it doesn't time out when I run glad2 from the command line at least.  As for the web service, let's ho[e that this rectifies the issue as I have no method of testing it to see if that is the only issue.