### PR TITLE
nim: fix compile error when using latest nim

### DIFF
--- a/glad/lang/nim/loader/gl.py
+++ b/glad/lang/nim/loader/gl.py
@@ -17,11 +17,11 @@ bool gladLoadGL()
 '''
 
 _OPENGL_HAS_EXT_LT3 = '''proc hasExt(extname: string): bool =
-  if extname == nil:
+  if extname.len == 0:
     return false
 
   var extensions = $cast[cstring](glGetString(GL_EXTENSIONS))
-  if extensions == nil:
+  if extensions.len == 0:
     return false
 
   var
@@ -46,12 +46,12 @@ _OPENGL_HAS_EXT_LT3 = '''proc hasExt(extname: string): bool =
 '''
 
 _OPENGL_HAS_EXT_GTE3 = '''proc hasExt(extname: string): bool =
-  if extname == nil:
+  if extname.len == 0:
     return false
 
   if glVersionMajor < 3:
     var extensions = $cast[cstring](glGetString(GL_EXTENSIONS))
-    if extensions == nil:
+    if extensions.len == 0:
       return false
 
     var


### PR DESCRIPTION
I got following compile error with Nim 0.20.0.
```
glad/gl.nim(2259, 14) Error: 'nil' is now invalid for 'string'; compile with --nilseqs:on for a migration period; usage of '==' is a user-defined error
```
Empty ``string`` should be checked with ``someString.len == 0`` in current Nim.