### PR TITLE
Disabled Clippy to silence warnings

### DIFF
--- a/glad/generator/rust/templates/lib.rs
+++ b/glad/generator/rust/templates/lib.rs
@@ -1,1 +1,2 @@
+#[allow(clippy::all)]
 pub mod {{ spec.name }};


### PR DESCRIPTION
Fixes #248, stops Clippy from spewing warnings everywhere.