### PR TITLE
c: Fix generation of struct aliases

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "typeinfo": "cpp"
+    }
+}

--- a/glad/generator/c/templates/template_utils.h
+++ b/glad/generator/c/templates/template_utils.h
@@ -53,7 +53,7 @@ typedef enum {{ type.name }} {
 } {{ type.name }};
 {%- endif -%}
 {%- elif type.category in ('struct', 'union') -%}
-typedef {{ type.category }} {{ type.name }} {% if type.members %}{
+typedef {{ type.category }} {% if type.alias %}{{ type.alias }}{% else %}{{ type.name }}{% endif %} {% if type.members %}{
 {% for member in type.members %}
     {{ member.type._raw }};
 {% endfor %}


### PR DESCRIPTION
This commit fixes the issue presented by #271 by checking if the struct has an alias. If so, the alias field should be the struct name, rather than the name field of the spec.