### PR TITLE
Fix CMake IPO warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,11 @@ if(NOT CMAKE_VERSION VERSION_LESS 3.1)
   cmake_policy(SET CMP0054 NEW)
 endif()
 
+if(CMAKE_VERSION VERSION_GREATER 3.8)
+  # Enable IPO for CMake versions that support it
+  cmake_policy(SET CMP0069 NEW)
+endif()
+
 project(GLAD VERSION 0.1.33 LANGUAGES C)
 
 set(GLAD_DIR "${CMAKE_CURRENT_SOURCE_DIR}")


### PR DESCRIPTION
If you enable IPO in your own CMakeLists.txt and then include glad via add_subdirectory like this.
```cmake
include(CheckIPOSupported)
check_ipo_supported(RESULT ipo_result OUTPUT ipo_output)
if(ipo_result)
  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
endif()
(...)
add_subdirectory(extlib/glad)
```
Your going to get the following warning from CMake starting from version 3.9:
```
CMake Warning (dev) at extlib/glad/CMakeLists.txt:103 (add_library):
Policy CMP0069 is not set: INTERPROCEDURAL_OPTIMIZATION is enforced when
enabled.  Run "cmake --help-policy CMP0069" for policy details.  Use the
cmake_policy command to set the policy and suppress this warning.

INTERPROCEDURAL_OPTIMIZATION property will be ignored for target 'glad'.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

This patch should fix that warning and allow glad to be build with link time optimizations with non Intel compilers like Clang or GCC, when enabled. Tested on my local machine using CMake 3.17.3.

[CMP0069 Refernce](https://cmake.org/cmake/help/git-stage/policy/CMP0069.html)