### PR TITLE
Undefine APIENTRY at the end of glad.h

### DIFF
--- a/glad/lang/c/loader/gl.py
+++ b/glad/lang/c/loader/gl.py
@@ -135,10 +135,12 @@ _OPENGL_HEADER_INCLUDE_ERROR = '''
 _OPENGL_HEADER = '''
 #if defined(_WIN32) && !defined(APIENTRY) && !defined(__CYGWIN__) && !defined(__SCITECH_SNAP__)
 #define APIENTRY __stdcall
+#define GLAD_DEFINED_APIENTRY
 #endif
 
 #ifndef APIENTRY
 #define APIENTRY
+#define GLAD_DEFINED_APIENTRY
 #endif
 #ifndef APIENTRYP
 #define APIENTRYP APIENTRY *
@@ -169,6 +171,11 @@ GLAPI int gladLoadGL(void);
 _OPENGL_HEADER_END = '''
 #ifdef __cplusplus
 }
+#endif
+
+#if defined(GLAD_DEFINED_APIENTRY)
+#undef APIENTRY
+#undef GLAD_DEFINED_APIENTRY
 #endif
 
 #endif


### PR DESCRIPTION
Previously, including `Windows.h` after `glad.h` would trigger a warning due to `APIENTRY` being redefined by the former. Undefining `APIENTRY` prevents that problem.

Closes #283 