### PR TITLE
Delphi compiler support

### DIFF
--- a/example/pascal/sdl_glad.pas
+++ b/example/pascal/sdl_glad.pas
@@ -1,0 +1,91 @@
+(*
+  Generate GLAD:   python -m glad --out-path=build --api="gl=2.1" --extensions="" --generator="pascal"
+  Build sdl_glad:  fpc -B -Fu../../build/glad/ sdl_glad.pas
+*)  
+
+program sdl_glad;
+{$IF Defined(FPC)}
+{$MODE Delphi}
+{$ENDIF}
+  uses SysUtils, SDL2, glad_gl;
+
+var
+  window: PSDL_Window;
+  renderer: PSDL_Renderer;
+  event: PSDL_Event ;
+  running: Boolean;
+  gl_context: TSDL_GLContext;
+  
+begin  
+
+  if SDL_Init(SDL_INIT_VIDEO) <> 0 then
+  begin
+    WriteLn(Format('SDL2 video subsystem couldn''t be initialized. Error: %d', [SDL_GetError()]));
+    Halt(1);
+  end;
+
+  window := SDL_CreateWindow('SDL & Glad Sample',
+    SDL_WINDOWPOS_CENTERED,
+    SDL_WINDOWPOS_CENTERED,
+    800, 600, SDL_WINDOW_SHOWN or SDL_WINDOW_OPENGL);
+
+  renderer := SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED);
+  if not Assigned(renderer) then
+  begin
+    WriteLn(Format('SDL2 Renderer couldn''t be created. Error: %d', [SDL_GetError()]));
+    Halt(1);
+  end;
+
+  (* Create a OpenGL context on SDL2 *)
+  gl_context := SDL_GL_CreateContext(window);
+
+  (* Load GL extensions using glad *)
+  if gladLoadGL(@SDL_GL_GetProcAddress) = False then
+  begin
+    WriteLn('Failed to initialize the OpenGL context.');
+    Halt(1);
+  end;
+
+  (* Loaded OpenGL successfully. *)
+  WriteLn(Format('OpenGL version loaded: %d.%d',[glVersionMajor, glVersionMinor]));
+  (* Create an event handler *)
+  New(event);
+  (* Loop condition *)
+  running := True;
+    
+  while running = True do
+  begin
+
+    SDL_PollEvent(event);
+
+    case event.type_ of
+      SDL_QUITEV:
+        running := false;
+
+      SDL_KEYDOWN:
+        case event.key.keysym.sym of 
+          SDLK_ESCAPE:
+            running := false;
+        end;
+    end;
+
+    glClearColor(0, 0, 0, 1);
+
+    (* You'd want to use modern OpenGL here *)
+    glColor3d(0, 1, 0);
+    glBegin(GL_TRIANGLES);
+    glVertex2f(0.2, 0);
+    glVertex2f(0.01, 0.2);
+    glVertex2f(-0.2, 0);
+    glEnd();
+
+    SDL_GL_SwapWindow(window);
+  end;
+
+  (* Destroy everything to not leak memory. *)
+  SDL_GL_DeleteContext(gl_context);
+  SDL_DestroyRenderer(renderer);
+  SDL_DestroyWindow(window);
+
+  SDL_Quit();
+end.

--- a/glad/lang/pascal/generator.py
+++ b/glad/lang/pascal/generator.py
@@ -186,24 +186,17 @@ class PascalGenerator(Generator):
         f.write('{\n')
         f.write(self.header)
         f.write('}\n')
-        f.write('''{$MODE objfpc}{$H+}
-{$MACRO ON}
-{$IFDEF Windows}
-  {$DEFINE extdecl := stdcall}
-{$ELSE}
-  {$DEFINE extdecl := cdecl}
-{$ENDIF}
-''')
         f.write('unit glad_gl;\n\n')
+        f.write('{$IF Defined(FPC)}{$MODE Delphi}{$ENDIF}{$H+}\n\n')        
         f.write('interface\n\n')
-        f.write('uses\n  sysutils;\n\n')
+        f.write('uses\n  SysUtils, StrUtils;\n\n')
         f.write('var\n  glVersionMajor, glVersionMinor: integer;\n\n')
 
     def generate_loader(self, features, extensions):
         f = self._f_gl
 
         # finish interface
-        f.write('type\n  TLoadProc = function(proc: Pchar): Pointer;\n\n')
+        f.write('type\n  TLoadProc = function(proc: PAnsiChar): Pointer;\n\n')
         loadername = 'Load' if self.LOAD_GL_PREFIX else 'load'
         loader_decl = 'function {}{}{}(load: TLoadProc): boolean;\n'
         for api, version in self.api.items():
@@ -277,8 +270,8 @@ class PascalGenerator(Generator):
 
     def write_func_definition(self, fobj, func):
         func_name = self.map_func_name(func)
-        fobj.write('  pointer( {0} ) := load(\'{0}\');\n'.format(func_name))
-
+        fobj.write('  {0} := load(\'{0}\');\n'.format(func_name))
+        
     def map_func_name(self, func):
         name = func.proto.name
         return name
@@ -397,8 +390,7 @@ class PascalGenerator(Generator):
         fobj.write(')')
         if is_func:
             fobj.write(': {}'.format(ret))
-        fobj.write('; extdecl;')
-
+        fobj.write('; {$IF Defined(Windows) or Defined(MSWindows)}stdcall;{$ELSE}cdecl;{$ENDIF}');
     PASCAL_KEYWORDS = [  # conflicting keywords only
         'array', 'end', 'in', 'label', 'object', 'out', 'packed', 'program', 'string', 'type', 'unit'
     ]

--- a/glad/lang/pascal/loader/gl.py
+++ b/glad/lang/pascal/loader/gl.py
@@ -61,11 +61,11 @@ begin
 '''
 
 _BEGIN_LOAD = '''var
-  glVersion: pchar;
+  glVersion: PAnsiChar;
 begin
-  pointer( glGetString ) := load('glGetString');
-  if glGetString = nil then exit(false);
-  glVersion := PChar( glGetString(GL_VERSION) );
+  glGetString := load('glGetString');  
+  if not Assigned(glGetString) then exit(false);
+  glVersion := PAnsiChar( glGetString(GL_VERSION) );
   if glVersion = nil then exit(false);
 
 '''


### PR DESCRIPTION
Support for Embarcadero Delphi compiler. Tested on Windows 10 - GLFW3, FPC 3.0.4 and Delphi CE.