### PR TITLE
Fix for CMAKE_STAGING_PREFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,9 +91,7 @@ add_library(glad ${GLAD_SOURCES})
 add_dependencies(glad glad-generate-files)
 target_include_directories(glad
     PUBLIC
-        $<BUILD_INTERFACE:${GLAD_INCLUDE_DIRS}>
-    INTERFACE
-        $<INSTALL_INTERFACE:include/glad>)
+        $<BUILD_INTERFACE:${GLAD_INCLUDE_DIRS}>)
 
 # Are we building a shared library?
 get_target_property(library_type glad TYPE)
@@ -134,7 +132,7 @@ endif()
 # Install
 if(GLAD_INSTALL)
 
-  set(config_install_dir "lib/cmake/glad")
+  set(config_install_dir lib/cmake/glad)
   set(version_config "${CMAKE_CURRENT_BINARY_DIR}/gladConfigVersion.cmake")
   set(project_config "${CMAKE_CURRENT_BINARY_DIR}/gladConfig.cmake")
   set(targets_export_name "gladTargets")
@@ -158,26 +156,25 @@ if(GLAD_INSTALL)
   install(
     TARGETS glad
     EXPORT "${targets_export_name}"
-    LIBRARY DESTINATION "lib"
-    ARCHIVE DESTINATION "lib"
-    RUNTIME DESTINATION "bin"
-    INCLUDES DESTINATION "include")
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin)
 
-  if(GLAD_INCLUDE_DIRS)
-    install(
-      DIRECTORY ${GLAD_INCLUDE_DIRS}
-      DESTINATION ${CMAKE_INSTALL_PREFIX})
-  endif()
+  install(FILES ${GLAD_INCLUDE_DIRS}/glad/glad.h
+    DESTINATION include/glad)
+
+  install(FILES ${GLAD_INCLUDE_DIRS}/KHR/khrplatform.h
+    DESTINATION include/KHR)
 
   # Install gladConfig.cmake, gladConfigVersion.cmake
   install(
     FILES "${project_config}" "${version_config}"
-    DESTINATION "${config_install_dir}")
+    DESTINATION ${config_install_dir})
 
   # Create and install gladTargets.cmake
   install(
     EXPORT "${targets_export_name}"
     NAMESPACE "${namespace}"
-    DESTINATION "${config_install_dir}")
+    DESTINATION ${config_install_dir})
 
 endif()


### PR DESCRIPTION
CMAKE_STAGING_PREFIX is used to stage artifacts prior to actual install step.  Then other build stages can use this "staged sysroot" using just a prefix.