### PR TITLE
Added the include directories usage requirements to the install tree in CMakelists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,8 @@ add_library(glad ${GLAD_SOURCES})
 add_dependencies(glad glad-generate-files)
 target_include_directories(glad
     PUBLIC
-        $<BUILD_INTERFACE:${GLAD_INCLUDE_DIRS}>)
+        $<BUILD_INTERFACE:${GLAD_INCLUDE_DIRS}>
+	$<INSTALL_INTERFACE:include>)
 
 # Are we building a shared library?
 get_target_property(library_type glad TYPE)


### PR DESCRIPTION
i added the INSTALL_INTERFACE generator expression in target_include_directories command

so that upon installation of the library , include directories usage requirements properties can be propagated from the exported target glad to consumer targets and hence have access to those header files.


