### PR TITLE
Enhanced CMake support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,9 @@ cmake_policy(SET CMP0048 NEW)
 # Enable MACOSX_RPATH by default
 cmake_policy(SET CMP0042 NEW)
 
+# Allow "IN_LIST" in "IF()"
+cmake_policy(SET CMP0057 NEW)
+
 if(NOT CMAKE_VERSION VERSION_LESS 3.1)
   # Silence warning about if()
   cmake_policy(SET CMP0054 NEW)
@@ -36,7 +39,9 @@ set(GLAD_PROFILE "compatibility" CACHE STRING "OpenGL profile")
 set(GLAD_API "" CACHE STRING "API type/version pairs, like \"gl=3.2,gles=\", no version means latest")
 set(GLAD_GENERATOR "c" CACHE STRING "Language to generate the binding for")
 set(GLAD_EXTENSIONS "" CACHE STRING "Path to extensions file or comma separated list of extensions, if missing all extensions are included")
-set(GLAD_SPEC "gl" CACHE STRING "Name of the spec")
+set(GLAD_SPEC "gl" CACHE STRING "Name of the spec or list of multiple specs (separated by semicolons).")
+set(ARG_GLAD_SPEC "gl")
+set(HAS_EGL OFF)
 option(GLAD_ALL_EXTENSIONS "Include all extensions instead of those specified by GLAD_EXTENSIONS" OFF)
 option(GLAD_NO_LOADER "No loader" OFF)
 option(GLAD_REPRODUCIBLE "Reproducible build" OFF)
@@ -73,10 +78,45 @@ elseif(GLAD_GENERATOR STREQUAL "volt")
   )
 else()
   set(GLAD_INCLUDE_DIRS "${GLAD_OUT_DIR}/include")
-  list(APPEND GLAD_SOURCES
-    "${GLAD_OUT_DIR}/src/glad.c"
-    "${GLAD_INCLUDE_DIRS}/glad/glad.h"
-  )
+  string(REPLACE "," ";" spec_list ${GLAD_SPEC})
+
+  if(NOT "gl" IN_LIST spec_list)
+    list(APPEND spec_list "gl")
+  endif()
+
+  set(extensions ${GLAD_EXTENSIONS})
+  separate_arguments(extensions)
+
+  foreach(spec ${spec_list})
+    if(${spec} STREQUAL "gl")
+      list(APPEND GLAD_HEADERS "${GLAD_INCLUDE_DIRS}/glad/glad.h")
+      list(APPEND GLAD_SOURCES 
+        "${GLAD_INCLUDE_DIRS}/glad/glad.h"
+        "${GLAD_OUT_DIR}/src/glad.c"
+      )
+    else()
+      list(APPEND GLAD_HEADERS "${GLAD_INCLUDE_DIRS}/glad/glad_${spec}.h")
+      list(APPEND GLAD_SOURCES 
+        "${GLAD_INCLUDE_DIRS}/glad/glad_${spec}.h"
+        "${GLAD_OUT_DIR}/src/glad_${spec}.c"
+      )
+    
+      # Append mandatory extensions.
+      if(${spec} STREQUAL "wgl")
+        if(NOT "WGL_ARB_extensions_string" IN_LIST extensions)
+          set (GLAD_EXTENSIONS "${GLAD_EXTENSIONS},WGL_ARB_extensions_string")
+        endif()
+        if(NOT "WGL_EXT_extensions_string" IN_LIST extensions)
+          set (GLAD_EXTENSIONS "${GLAD_EXTENSIONS},WGL_EXT_extensions_string")
+        endif()
+      elseif(${spec} STREQUAL "egl")
+        set(HAS_EGL ON)
+      endif()
+
+      # Add spec to command line argument.
+      set(ARG_GLAD_SPEC "${ARG_GLAD_SPEC},${spec}")
+    endif()
+  endforeach()
 endif()
 
 if(NOT GLAD_ALL_EXTENSIONS)
@@ -97,7 +137,7 @@ add_custom_command(
     --api=${GLAD_API}
     --generator=${GLAD_GENERATOR}
     ${GLAD_EXTENSIONS_ARG}
-    --spec=${GLAD_SPEC}
+    --spec=${ARG_GLAD_SPEC}
     ${GLAD_NO_LOADER_ARG}
     ${GLAD_REPRODUCIBLE_ARG}
   WORKING_DIRECTORY ${GLAD_DIR}
@@ -179,11 +219,16 @@ if(GLAD_INSTALL)
     ARCHIVE DESTINATION lib
     RUNTIME DESTINATION bin)
 
-  install(FILES ${GLAD_INCLUDE_DIRS}/glad/glad.h
+  install(FILES ${GLAD_HEADERS}
     DESTINATION include/glad)
 
   install(FILES ${GLAD_INCLUDE_DIRS}/KHR/khrplatform.h
     DESTINATION include/KHR)
+
+  if(HAS_EGL)
+    install(FILES ${GLAD_INCLUDE_DIRS}/EGL/eglplatform.h
+      DESTINATION include/EGL)
+  endif()
 
   # Install gladConfig.cmake, gladConfigVersion.cmake
   install(

--- a/glad/lang/c/generator.py
+++ b/glad/lang/c/generator.py
@@ -8,6 +8,7 @@ import glad.files
 
 
 KHRPLATFORM = 'https://raw.githubusercontent.com/KhronosGroup/EGL-Registry/master/api/KHR/khrplatform.h'
+EGLPLATFORM = 'https://raw.githubusercontent.com/KhronosGroup/EGL-Registry/master/api/EGL/eglplatform.h'
 
 
 _KHR_TYPE_REPLACEMENTS = {
@@ -43,6 +44,7 @@ class CGenerator(Generator):
             self._f_h = open(make_path(self.path,
                                         'glad{}.h'.format(suffix)), 'w')
             khr = self.path
+            egl = self.path
         else:
             self.h_include = '<glad/glad{}.h>'.format(suffix)
             self._f_c = open(make_path(self.path, 'src',
@@ -50,6 +52,7 @@ class CGenerator(Generator):
             self._f_h = open(make_path(self.path, 'include', 'glad',
                                         'glad{}.h'.format(suffix)), 'w')
             khr = os.path.join(self.path, 'include', 'KHR')
+            egl = os.path.join(self.path, 'include', 'EGL')
 
         if not self.omit_khrplatform:
             khr_url = KHRPLATFORM
@@ -67,6 +70,24 @@ class CGenerator(Generator):
                             dst.write(src.read())
                 else:
                     self.opener.urlretrieve(khr_url, khrplatform)
+
+            if self.spec.NAME == 'egl':
+                egl_url = EGLPLATFORM
+                if os.path.exists('eglplatform.h'):
+                    egl_url = 'file:' + os.path.abspath('eglplatform.h')
+                    
+                eglplatform = os.path.join(egl, 'eglplatform.h')
+                if not os.path.exists(eglplatform):
+                    if not os.path.exists(egl):
+                        os.makedirs(egl)
+
+                    if self.options.get('reproducible', False):
+                        with glad.files.open_local('eglplatform.h', 'rb') as src:
+                            with open(eglplatform, 'wb') as dst:
+                                dst.write(src.read())
+                    else:
+                        self.opener.urlretrieve(egl_url, eglplatform)
+
 
         return self
 

--- a/glad/lang/common/generator.py
+++ b/glad/lang/common/generator.py
@@ -97,8 +97,8 @@ class Generator(object):
 
             if version not in self.spec.features[api]:
                 raise ValueError(
-                    'Unknown version "{0}" for specification "{1}"'
-                    .format(version, self.spec.NAME)
+                    'Unknown version "{0}" for specification "{1}" and API "{2}"'
+                    .format(version, self.spec.NAME, api)
                 )
 
         if self.extension_names is None:

--- a/glad/lang/common/generator.py
+++ b/glad/lang/common/generator.py
@@ -107,15 +107,6 @@ class Generator(object):
 
         # sort and eliminate duplicates
         self.extension_names = list(sorted(set(self.extension_names)))
-
-        e = list(chain.from_iterable(self.spec.extensions[a] for a in self.api))
-        for ext in self.extension_names:
-            if ext not in e:
-                raise ValueError(
-                    'Invalid extension "{0}" for specification "{1}"'
-                    .format(ext, self.spec.NAME)
-                )
-
         self.generate_header()
 
         types = [t for t in self.spec.types if t.api is None or t.api in self.api]


### PR DESCRIPTION
This PR enhances the ability to generate GLAD (1) from CMake, but also addresses other generator issues. 

First of all, it fixes a bug that produces invalid builds when a different `GLAD_SPEC` than `gl` was specified (see issue #314). Since all other specs depend on the `gl` spec (i.e. the generated `glad.h` and `glad.c` code) to be present, I also had to introduce support for generating code for multiple specs, similar to PR #276. However, different to it, this PR does not introduce an additional command line argument, but instead extents `GLAD_SPEC` and `--spec` to support a list of specs instead. Furthermore, this PR also adds the generated headers to the install list, allowing to properly install the CMake target.

Since the `gl` spec is always required, it is added by default (if not present) within the CMakeLists.txt. It can be omitted in the `--spec` argument of the python generator scripts, in which case they produce the same output as before. The generator scripts now split the `--spec` argument and iterate all available scripts, running a generator on each. This, however, meant that I had to drop early validation for the argument (argparse `choices` did not work with `nargs` here 😕). If an unsupported spec is specified, no generator will be detected and the script fails.

When specifying multiple specs in combination with a set of extensions, the generator will fail, if it does not know the extension. However, there is no actual requirement for raising an error in this case, since it can also simply ignore the extension. I therefor removed the error from the generator and did not encounter any issues. This does not have any effect, if `GLAD_ALL_EXTENSIONS` is specified (or `--extension` is empty).

Additionally, I've improved handling for `wgl` and `egl` specs: 
- When generating code for the `wgl` spec, the generated code uses functions that are only defined, if `WGL_ARB_extensions_string` and `WGL_EXT_extensions_string`, hence the CMakeLists.txt adds those extensions, if it detects the `wgl` spec and does not find those extensions. This change does not effect the python generator script and does not have any effect, if `GLAD_ALL_EXTENSIONS` is enabled.
- The `egl` spec depends on the `eglplatform.h` header to be present. I've improved the generator to automatically download it from the egl registry, similar to how the `khrplatform.h` header is handled. It is only downloaded, if the `egl` spec is enabled and the `omit_khrplatform` flag is not set.

Furthermore, it should be possible to use GLAD as a git submodule with those changes and integrate it using CMake.

#### Things I could not test:

- Generating glx spec.
- Non C/C++ generators. Note that I did not do any obvious changes to the logic, so the generators should still work the same as previously.

#### Usage examples:

```shell
# Default build: generates default glad.h/glad.c ( `gl` spec) headers with all extensions enabled.
cmake -B ./build/
cmake --build ./build/

# Default build: generates default glad.h/glad.c ( `gl` spec) headers with no extensions.
cmake -DGLAD_ALL_EXTENSIONS=OFF -B ./build-min/
cmake --build ./build-min/

# Generate `gl`, `wgl` and `egl` specs
cmake -DGLAD_SPEC="wgl,egl" -B ./build-wgl-egl/
cmake --build ./build-wgl-egl/

# Same as above, but with installer.
cmake -DGLAD_SPEC="wgl,egl" -DGLAD_INSTALL=ON -DCMAKE_INSTALL_PREFIX="./install/" -B ./build-install/
cmake --build ./build-install/ --target install
```