### PR TITLE
Glad2 CMake Rework

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -6,7 +6,7 @@
 #    GLAD_SOURCES_DIR: path to the sources of glad (=python module)
 #
 #
-#  glad_add_library(<TARGET> [SHARED|STATIC|MODULE] [EXCLUDE_FROM_ALL] [MERGE] [QUIET] [KEEP_SOURCES] [LOCATION <PATH>]
+#  glad_add_library(<TARGET> [SHARED|STATIC|MODULE] [EXCLUDE_FROM_ALL] [MERGE] [QUIET] [LOCATION <PATH>]
 #                       [LANGUAGE <LANG>] [API <API1> [<API2> ...]] [EXTENSIONS [<EXT1> [<EXT2> ...]]])
 #  - <TARGET>
 #       Name of the TARGET
@@ -18,12 +18,8 @@
 #       Merge multiple APIs of the same specitifation into one file.
 #   - QUIET
 #       Disable logging
-#   - KEEP_SOURCES
-#       After generating the sources, do not let a clean step remove the sources.
-#       This is useful for adding the glad sources to your scm.
 #   - LOCATION <PATH>
 #       Set the location where the generated glad should be saved.
-#       If KEEP_SOURCES is also defined, this path can be inside the source path.
 #   - LANGUAGE <LANG>
 #       Language of the generated glad sources.
 #   - API <API1> [<API2> ...]]
@@ -42,13 +38,13 @@
 #   ```
 # - create  a static glad library with the vulkan=1.1
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.2)
 project(glad C)
 
 find_package(PythonInterp REQUIRED)
 
 set(GLAD_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}" CACHE STRING "Directory containing glad generator CMakeLists.txt")
-set(GLAD_SOURCES_DIR "${GLAD_CMAKE_DIR}/../" CACHE STRING "Directory containing glad sources (python modules), used as working directory")
+set(GLAD_SOURCES_DIR "${GLAD_CMAKE_DIR}/../"   CACHE STRING "Directory containing glad sources (python modules), used as working directory")
 mark_as_advanced(GLAD_CMAKE_DIR)
 
 # Extract specification, profile and version from a string
@@ -178,8 +174,10 @@ endfunction()
 
 # Create a glad library named "${TARGET}"
 function(glad_add_library TARGET)
-    cmake_parse_arguments(GG "MERGE;QUIET;REPRODUCIBLE;KEEP_SOURCES;STATIC;SHARED;MODULE;EXCLUDE_FROM_ALL" "LOCATION;LANGUAGE" "API;EXTENSIONS" ${ARGN})
-
+    message(STATUS "Glad Library \'${TARGET}\'")
+    
+    cmake_parse_arguments(GG "MERGE;QUIET;REPRODUCIBLE;STATIC;SHARED;MODULE;EXCLUDE_FROM_ALL" "LOCATION;LANGUAGE" "API;EXTENSIONS" ${ARGN})
+    
     if(NOT GG_LOCATION)
         set(GG_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/gladsources/${TARGET}")
     endif()
@@ -230,48 +228,22 @@ function(glad_add_library TARGET)
     endif()
     list(APPEND GLAD_ARGS ${GLAD_LANGUAGE} ${LANG_ARGS})
 
-    # allows:
-    # - bootstrap: generate sources when non-existent
-    # - do not remove the sources when cleaning
-    # BUG: running clean directly after an initial make without sources present, removes the sources
-
-    if(GG_KEEP_SOURCES)
-        string(REPLACE "${GLAD_DIR}" GLAD_DIRECTORY GLAD_ARGS_UNIVERSAL "${GLAD_ARGS}")
-        set(GLAD_ADD_CUSTOM_COMMAND OFF)
-        set(GLAD_ARGS_PATH "${GLAD_DIR}/args.txt")
-        if(NOT EXISTS "${GLAD_ARGS_PATH}")
-            set(GLAD_ADD_CUSTOM_COMMAND ON)
-        else()
-            file(READ "${GLAD_ARGS_PATH}" GLAD_ARGS_FILE)
-            if(NOT GLAD_ARGS_UNIVERSAL STREQUAL GLAD_ARGS_FILE)
-                set(GLAD_ADD_CUSTOM_COMMAND ON)
-            endif()
-        endif()
-        list(APPEND GLAD_EXTRA_COMMANDS
-            COMMAND "${CMAKE_COMMAND}" "-DPATH=${GLAD_ARGS_PATH}" "-DTEXT=\"${GLAD_ARGS_UNIVERSAL}\"" -P "${GLAD_CMAKE_DIR}/WriteFile.cmake"
-            COMMAND "${CMAKE_COMMAND}" -E sleep 1
-            COMMAND "${CMAKE_COMMAND}" -E touch "${GLAD_CMAKE_DIR}/CMakeLists.txt"
-            )
-    else()
-        set(GLAD_ADD_CUSTOM_COMMAND ON)
-    endif()
-
-    if(GLAD_ADD_CUSTOM_COMMAND)
-        add_custom_command(OUTPUT ${GLAD_FILES} ${GLAD_ARGS_PATH}
-            COMMAND "${CMAKE_COMMAND}" -E remove_directory "${GLAD_DIR}"
-            COMMAND "${PYTHON_EXECUTABLE}" -m glad ${GLAD_ARGS}
-            ${GLAD_EXTRA_COMMANDS}
-            WORKING_DIRECTORY "${GLAD_SOURCES_DIR}"
-            )
-    endif()
+    string(REPLACE "${GLAD_DIR}" GLAD_DIRECTORY GLAD_ARGS_UNIVERSAL "${GLAD_ARGS}")
+    set(GLAD_ARGS_PATH "${GLAD_DIR}/args.txt")
 
     # add make custom target
-    add_custom_target("regenerate_${TARGET}"
-        COMMAND "${CMAKE_COMMAND}" -E remove_directory "${GLAD_DIR}"
-        COMMAND "${PYTHON_EXECUTABLE}" -m glad ${GLAD_ARGS}
-        ${GLAD_EXTRA_COMMANDS}
-        WORKING_DIRECTORY "${GLAD_SOURCES_DIR}"
-        COMMENT "Regenerating glad source files for ${TARGET}..."
+    add_custom_command(
+        OUTPUT ${GLAD_FILES} ${GLAD_ARGS_PATH}
+        COMMAND echo Cleaning ${GLAD_DIR}
+        COMMAND ${CMAKE_COMMAND} -E remove_directory ${GLAD_DIR}
+        COMMAND ${CMAKE_COMMAND} -E make_directory   ${GLAD_DIR}
+        COMMAND echo Generating with args ${GLAD_ARGS}
+        COMMAND ${PYTHON_EXECUTABLE} -m glad ${GLAD_ARGS}
+        COMMAND echo Writing ${GLAD_ARGS_PATH}
+        COMMAND echo ${GLAD_ARGS} > ${GLAD_ARGS_PATH}
+        WORKING_DIRECTORY ${GLAD_SOURCES_DIR}
+        COMMENT "${TARGET}-generate"
+        USES_TERMINAL
         )
 
     set(GLAD_ADD_LIBRARY_ARGS "")

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -6,12 +6,12 @@
 #    GLAD_SOURCES_DIR: path to the sources of glad (=python module)
 #
 #
-#  glad_add_library(<TARGET> [SHARED|STATIC|MODULE] [EXCLUDE_FROM_ALL] [MERGE] [QUIET] [LOCATION <PATH>]
+#  glad_add_library(<TARGET> [SHARED|STATIC|MODULE|INTERFACE] [EXCLUDE_FROM_ALL] [MERGE] [QUIET] [LOCATION <PATH>]
 #                       [LANGUAGE <LANG>] [API <API1> [<API2> ...]] [EXTENSIONS [<EXT1> [<EXT2> ...]]])
 #  - <TARGET>
 #       Name of the TARGET
-#  - SHARED|STATIC|MODULE
-#       Type of the library
+#  - SHARED|STATIC|MODULE|INTERFACE
+#       Type of the library, if none is specified, default BUILD_SHARED_LIBS behavior is honored
 #   - EXCLUDE_FROM_ALL
 #       Exclude building the library from the all target
 #   - MERGE
@@ -176,7 +176,7 @@ endfunction()
 function(glad_add_library TARGET)
     message(STATUS "Glad Library \'${TARGET}\'")
     
-    cmake_parse_arguments(GG "MERGE;QUIET;REPRODUCIBLE;STATIC;SHARED;MODULE;EXCLUDE_FROM_ALL" "LOCATION;LANGUAGE" "API;EXTENSIONS" ${ARGN})
+    cmake_parse_arguments(GG "MERGE;QUIET;REPRODUCIBLE;STATIC;SHARED;MODULE;INTERFACE;EXCLUDE_FROM_ALL" "LOCATION;LANGUAGE" "API;EXTENSIONS" ${ARGN})
     
     if(NOT GG_LOCATION)
         set(GG_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/gladsources/${TARGET}")
@@ -247,20 +247,21 @@ function(glad_add_library TARGET)
         )
 
     set(GLAD_ADD_LIBRARY_ARGS "")
-
     if(GG_SHARED)
         list(APPEND GLAD_ADD_LIBRARY_ARGS SHARED)
     elseif(GG_STATIC)
         list(APPEND GLAD_ADD_LIBRARY_ARGS STATIC)
     elseif(GG_MODULE)
         list(APPEND GLAD_ADD_LIBRARY_ARGS MODULE)
+    elseif(GG_INTERFACE)
+        list(APPEND GLAD_ADD_LIBRARY_ARGS INTERFACE)
     endif()
 
     if(GG_EXCLUDE_FROM_ALL)
         list(APPEND GLAD_ADD_LIBRARY_ARGS EXCLUDE_FROM_ALL)
     endif()
 
-    add_library("${TARGET}" ${LIBTYPE} ${GLAD_ADD_LIBRARY_ARGS}
+    add_library("${TARGET}" ${GLAD_ADD_LIBRARY_ARGS}
         ${GLAD_FILES}
         )
 

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -274,4 +274,12 @@ function(glad_add_library TARGET)
         PUBLIC
             ${CMAKE_DL_LIBS}
         )
+        
+    if(GG_SHARED)
+        target_compile_definitions("${TARGET}" PUBLIC GLAD_API_CALL_EXPORT)
+        set_target_properties("${TARGET}"
+            PROPERTIES
+            DEFINE_SYMBOL "GLAD_API_CALL_EXPORT_BUILD"
+            )
+    endif()
 endfunction()

--- a/cmake/WriteFile.cmake
+++ b/cmake/WriteFile.cmake
@@ -1,2 +1,0 @@
-# Helper cmake script to write the string "${TEXT}" to the file "${FILE}"
-file(WRITE "${PATH}" "${TEXT}")


### PR DESCRIPTION
Changes:
- Switched over `add_custom_command()` to create a file-based dependency with `OUTPUT ${GLAD_FILES} ${GLAD_ARGS_PATH}` on which added libraries depend on.
This `${TARGET}-generate` step is properly re-triggered only if one of its arguments changes and regeneration is needed.
Kept the `remove_directory()` for safety, but It may not be needed given how `GLAD_FILES` are very selective.
Sources should not be deleted afterwards, no reason to hide what we just generated, that's harder to debug.

- Fixed Shared Library building

- Not outrageous CMake minimal version bump to 3.2

- Allowed Interface Libraries for those with CMake 3.19+

- Removed unused `LIBTYPE`

Related to #319

