### PR TITLE
c: zero-initializes parsed GL version numbers

### DIFF
--- a/glad/generator/c/templates/gl.c
+++ b/glad/generator/c/templates/gl.c
@@ -153,7 +153,7 @@ static int glad_gl_find_extensions_{{ api|lower }}({{ template_utils.context_arg
 }
 
 static int glad_gl_find_core_{{ api|lower }}({{ template_utils.context_arg(def='void') }}) {
-    int i, major, minor;
+    int i;
     const char* version;
     const char* prefixes[] = {
         "OpenGL ES-CM ",
@@ -161,6 +161,8 @@ static int glad_gl_find_core_{{ api|lower }}({{ template_utils.context_arg(def='
         "OpenGL ES ",
         NULL
     };
+    int major = 0;
+    int minor = 0;
     version = (const char*) {{ 'glGetString'|ctx }}(GL_VERSION);
     if (!version) return 0;
     for (i = 0;  prefixes[i];  i++) {


### PR DESCRIPTION
If an unsupported GL_VERSION prefix string is encountered, the sscanf()
call used to parse the version number values may fail. When this occurs,
"major" and "minor" will be left uninitialized, which leads to undefined
behavior when using these values later.

This change addresses the issue by making sure "major" and "minor" are
initialized to zero. If the sscanf() call fails, subsequent checks
against these version number values will at least have consistent
results.