### PR TITLE
glad: adds OpenGL SC support for GL_VERSION string parsing

### DIFF
--- a/glad/generator/c/templates/gl.c
+++ b/glad/generator/c/templates/gl.c
@@ -159,6 +159,7 @@ static int glad_gl_find_core_{{ api|lower }}({{ template_utils.context_arg(def='
         "OpenGL ES-CM ",
         "OpenGL ES-CL ",
         "OpenGL ES ",
+        "OpenGL SC ",
         NULL
     };
     version = (const char*) {{ 'glGetString'|ctx }}(GL_VERSION);

--- a/glad/generator/d/templates/loader/gl.d
+++ b/glad/generator/d/templates/loader/gl.d
@@ -73,6 +73,7 @@ void find_core{{ feature_set.api|api }}() {
         "OpenGL ES-CM ".ptr,
         "OpenGL ES-CL ".ptr,
         "OpenGL ES ".ptr,
+        "OpenGL SC ".ptr,
     ];
 
     glversion = cast(const(char)*)glGetString(GL_VERSION);

--- a/glad/generator/volt/templates/loader/gl.volt
+++ b/glad/generator/volt/templates/loader/gl.volt
@@ -75,6 +75,7 @@ fn find_core{{ feature_set.api|api }}() {
         "OpenGL ES-CM ".ptr,
         "OpenGL ES-CL ".ptr,
         "OpenGL ES ".ptr,
+        "OpenGL SC ".ptr,
     ];
 
     glversion = cast(const(char)*)glGetString(GL_VERSION);


### PR DESCRIPTION
OpenGL SC drivers return GL_VERSION strings with the format "OpenGL SC
N.M vendor-specific information", so the string "OpenGL SC " should be
included in the list of prefixes checked when parsing the GL_VERSION
string.