### PR TITLE
Fix MSVC compiler error C2099

### DIFF
--- a/glad/generator/c/templates/template_utils.h
+++ b/glad/generator/c/templates/template_utils.h
@@ -54,7 +54,7 @@ typedef enum {{ type.alias }} {{ type.name }};
 {% elif type.bitwidth == '64' %}
 typedef uint64_t {{ type.name }};
 {% for member in type.enums_for(feature_set) %}
-static const {{ member.parent_type }} {{ member.name }} = {{ enum_member(type, member) }};
+#define {{ member.name }} ({{ member.parent_type }}){{ enum_member(type, member) }}
 {% endfor %}
 {% else %}
 {%- if type.enums_for(feature_set) -%}


### PR DESCRIPTION
As title says, fixes compilation in MSVC.

It is a simple C template change which changes `static const type value;` into `#define (type)value` in those cases it was emiting a warning.