### PR TITLE
Implement is_descedant for Type and parse Type's parent and Member's enum

### DIFF
--- a/glad/parse.py
+++ b/glad/parse.py
@@ -844,6 +844,17 @@ class Type(IdentifiedByName):
     def is_equivalent(self, other):
         return self._raw == other._raw
 
+    def is_descendant(self, basetype, typeslist):
+        if self.name == basetype:
+            return True
+
+        cur = self
+        while cur.parent is not None:
+            if cur.parent == basetype:
+                return True
+            cur = typeslist[cur.parent][0]
+        return False;
+
     def __str__(self):
         return self.name
 


### PR DESCRIPTION
Having a way to filter Types by their parents allows Vulkan generators to load functions by type (similar to volk), and Member's enums can be used to set the array size of a particular Member.
This change is used with the generator mentioned in issue #368