### PR TITLE
[RFC] c: make mx context thread safe

### DIFF
--- a/glad/generator/c/templates/loader/egl.c
+++ b/glad/generator/c/templates/loader/egl.c
@@ -20,8 +20,6 @@ static GLADapiproc glad_egl_get_proc(void *vuserptr, const char* name) {
     return result;
 }
 
-static void* _egl_handle = NULL;
-
 static void* glad_egl_dlopen_handle(void) {
 #if GLAD_PLATFORM_APPLE
     static const char *NAMES[] = {"libEGL.dylib"};
@@ -31,11 +29,7 @@ static void* glad_egl_dlopen_handle(void) {
     static const char *NAMES[] = {"libEGL.so.1", "libEGL.so"};
 #endif
 
-    if (_egl_handle == NULL) {
-        _egl_handle = glad_get_dlopen_handle(NAMES, sizeof(NAMES) / sizeof(NAMES[0]));
-    }
-
-    return _egl_handle;
+    return glad_get_dlopen_handle(NAMES, sizeof(NAMES) / sizeof(NAMES[0]));
 }
 
 static struct _glad_egl_userptr glad_egl_build_userptr(void *handle) {
@@ -49,10 +43,8 @@ static struct _glad_egl_userptr glad_egl_build_userptr(void *handle) {
 int gladLoaderLoadEGL(EGLDisplay display) {
     int version = 0;
     void *handle = NULL;
-    int did_load = 0;
     struct _glad_egl_userptr userptr;
 
-    did_load = _egl_handle == NULL;
     handle = glad_egl_dlopen_handle();
     if (handle != NULL) {
         userptr = glad_egl_build_userptr(handle);
@@ -61,9 +53,7 @@ int gladLoaderLoadEGL(EGLDisplay display) {
             version = gladLoadEGLUserPtr(display, glad_egl_get_proc, &userptr);
         }
 
-        if (!version && did_load) {
-            gladLoaderUnloadEGL();
-        }
+        glad_close_dlopen_handle(handle);
     }
 
     return version;
@@ -82,13 +72,12 @@ static GLADapiproc glad_egl_internal_loader_get_proc(const char *name) {
 {% endif %}
 
 void gladLoaderUnloadEGL() {
-    if (_egl_handle != NULL) {
-        glad_close_dlopen_handle(_egl_handle);
-        _egl_handle = NULL;
 {% if options.on_demand %}
+    if (glad_egl_internal_loader_global_userptr.handle != NULL) {
+        glad_close_dlopen_handle(glad_egl_internal_loader_global_userptr.handle);
         glad_egl_internal_loader_global_userptr.handle = NULL;
-{% endif %}
     }
+{% endif %}
 }
 
 #endif /* GLAD_EGL */

--- a/glad/generator/c/templates/loader/gles2.c
+++ b/glad/generator/c/templates/loader/gles2.c
@@ -32,8 +32,6 @@ static GLADapiproc glad_gles2_get_proc(void *vuserptr, const char* name) {
     return result;
 }
 
-static void* _gles2_handle = NULL;
-
 static void* glad_gles2_dlopen_handle(void) {
 #if GLAD_PLATFORM_EMSCRIPTEN
 #elif GLAD_PLATFORM_APPLE
@@ -47,11 +45,7 @@ static void* glad_gles2_dlopen_handle(void) {
 #if GLAD_PLATFORM_EMSCRIPTEN
     return NULL;
 #else
-    if (_gles2_handle == NULL) {
-        _gles2_handle = glad_get_dlopen_handle(NAMES, sizeof(NAMES) / sizeof(NAMES[0]));
-    }
-
-    return _gles2_handle;
+    return glad_get_dlopen_handle(NAMES, sizeof(NAMES) / sizeof(NAMES[0]));
 #endif
 }
 
@@ -70,7 +64,6 @@ static struct _glad_gles2_userptr glad_gles2_build_userptr(void *handle) {
 int gladLoaderLoadGLES2{{ 'Context' if options.mx }}({{ template_utils.context_arg(def='void') }}) {
     int version = 0;
     void *handle = NULL;
-    int did_load = 0;
     struct _glad_gles2_userptr userptr;
 
 #if GLAD_PLATFORM_EMSCRIPTEN
@@ -81,16 +74,13 @@ int gladLoaderLoadGLES2{{ 'Context' if options.mx }}({{ template_utils.context_a
         return 0;
     }
 
-    did_load = _gles2_handle == NULL;
     handle = glad_gles2_dlopen_handle();
     if (handle != NULL) {
         userptr = glad_gles2_build_userptr(handle);
 
         version = gladLoadGLES2{{ 'Context' if options.mx }}UserPtr({{ 'context, ' if options.mx }}glad_gles2_get_proc, &userptr);
 
-        if (!version && did_load) {
-            gladLoaderUnloadGLES2();
-        }
+        gladLoaderUnloadGLES2();
     }
 #endif
 
@@ -116,13 +106,13 @@ int gladLoaderLoadGLES2(void) {
 {% endif %}
 
 void gladLoaderUnloadGLES2(void) {
-    if (_gles2_handle != NULL) {
-        glad_close_dlopen_handle(_gles2_handle);
-        _gles2_handle = NULL;
 {% if options.on_demand %}
-        glad_gles2_internal_loader_global_userptr.get_proc_address_ptr = NULL;
-{% endif %}
+    glad_gles2_internal_loader_global_userptr.get_proc_address_ptr = NULL;
+    if (glad_gles2_internal_loader_global_userptr.handle != NULL) {
+        glad_close_dlopen_handle(glad_gles2_internal_loader_global_userptr.handle);
+        glad_gles2_internal_loader_global_userptr.handle = NULL;
     }
+{% endif %}
 }
 
 #endif /* GLAD_GLES2 */


### PR DESCRIPTION
There is no reason to store the handle in `_gl{es}_handle` when not using an ondemand context, because all of the other context types can immediately unload the handle after using it, as part of the same scope.

This fixes a potential race condition when two threads try loading the handle at the same time.

Fixes: #383