### PR TITLE
c: store mx-global context as a pointer

### DIFF
--- a/glad/generator/c/templates/base_template.c
+++ b/glad/generator/c/templates/base_template.c
@@ -20,7 +20,7 @@ extern "C" {
 
 {% block variables %}
 {% if options.mx_global %}
-{% call template_utils.zero_initialized() %}Glad{{ feature_set.name|api }}Context {{ global_context }}{% endcall %}
+Glad{{ feature_set.name|api }}Context* {{ global_context }};
 {% endif %}
 {% endblock %}
 

--- a/glad/generator/c/templates/base_template.c
+++ b/glad/generator/c/templates/base_template.c
@@ -20,7 +20,8 @@ extern "C" {
 
 {% block variables %}
 {% if options.mx_global %}
-Glad{{ feature_set.name|api }}Context* {{ global_context }};
+{% call template_utils.zero_initialized() %}Glad{{ feature_set.name|api }}Context {{ global_context }}_static{% endcall %}
+Glad{{ feature_set.name|api }}Context* {{ global_context }} = &{{ global_context }}_static;
 {% endif %}
 {% endblock %}
 

--- a/glad/generator/c/templates/base_template.h
+++ b/glad/generator/c/templates/base_template.h
@@ -79,14 +79,14 @@ typedef struct Glad{{ feature_set.name|api }}Context {
 } Glad{{ feature_set.name|api }}Context;
 
 {% if options.mx_global %}
-GLAD_API_CALL Glad{{ feature_set.name|api }}Context glad_{{ feature_set.name }}_context;
+GLAD_API_CALL Glad{{ feature_set.name|api }}Context* glad_{{ feature_set.name }}_context;
 
 {% for extension in chain(feature_set.features, feature_set.extensions) %}
-#define GLAD_{{ extension.name }} (glad_{{ feature_set.name }}_context.{{ extension.name|no_prefix }})
+#define GLAD_{{ extension.name }} (glad_{{ feature_set.name }}_context->{{ extension.name|no_prefix }})
 {% endfor %}
 
 {% for command in feature_set.commands %}
-#define {{ command.name }} (glad_{{ feature_set.name }}_context.{{ command.name|no_prefix }})
+#define {{ command.name }} (glad_{{ feature_set.name }}_context->{{ command.name|no_prefix }})
 {% endfor %}
 {% endif %}
 

--- a/glad/generator/c/templates/gl.c
+++ b/glad/generator/c/templates/gl.c
@@ -230,11 +230,14 @@ int gladLoad{{ api|api }}(GLADloadfunc load) {
 
 {% if options.mx_global %}
 Glad{{ feature_set.name|api }}Context* gladGet{{ feature_set.name|api }}Context() {
-    return &{{ global_context }};
+    static Glad{{ feature_set.name|api }}Context default_context;
+    if (!{{ global_context }})
+        {{ global_context }} = &default_context;
+    return {{ global_context }};
 }
 
 void gladSet{{ feature_set.name|api }}Context(Glad{{ feature_set.name|api }}Context *context) {
-    {{ global_context }} = *context;
+    {{ global_context }} = context;
 }
 {% endif %}
 

--- a/glad/generator/c/templates/gl.c
+++ b/glad/generator/c/templates/gl.c
@@ -230,9 +230,6 @@ int gladLoad{{ api|api }}(GLADloadfunc load) {
 
 {% if options.mx_global %}
 Glad{{ feature_set.name|api }}Context* gladGet{{ feature_set.name|api }}Context() {
-    static Glad{{ feature_set.name|api }}Context default_context;
-    if (!{{ global_context }})
-        {{ global_context }} = &default_context;
     return {{ global_context }};
 }
 

--- a/glad/generator/c/templates/vk.c
+++ b/glad/generator/c/templates/vk.c
@@ -228,9 +228,6 @@ int gladLoad{{ api|api }}(VkPhysicalDevice physical_device, GLADloadfunc load) {
 
 {% if options.mx_global %}
 Glad{{ feature_set.name|api }}Context* gladGet{{ feature_set.name|api }}Context() {
-    static Glad{{ feature_set.name|api }}Context default_context;
-    if (!{{ global_context }})
-        {{ global_context }} = &default_context;
     return {{ global_context }};
 }
 

--- a/glad/generator/c/templates/vk.c
+++ b/glad/generator/c/templates/vk.c
@@ -228,11 +228,14 @@ int gladLoad{{ api|api }}(VkPhysicalDevice physical_device, GLADloadfunc load) {
 
 {% if options.mx_global %}
 Glad{{ feature_set.name|api }}Context* gladGet{{ feature_set.name|api }}Context() {
-    return &{{ global_context }};
+    static Glad{{ feature_set.name|api }}Context default_context;
+    if (!{{ global_context }})
+        {{ global_context }} = &default_context;
+    return {{ global_context }};
 }
 
 void gladSet{{ feature_set.name|api }}Context(Glad{{ feature_set.name|api }}Context *context) {
-    {{ global_context }} = *context;
+    {{ global_context }} = context;
 }
 {% endif %}
 


### PR DESCRIPTION
Instead of a separate struct that needs to be copied by-value. This will reduce the risk of accidentally ending up with an inconsistent context state.

We still need a default context in the even that a user loads an `mx-global` context without ever supplying a custom struct, but this is easy enough to return in an ad-hoc fashion whenever `gladGet*Context` is called without a context otherwise being bound.

(Incidentally, the way this logic is implemented also lets you recover the global context by explicitly calling `gladSet*Context(NULL)`)