### PR TITLE
c generator: Allow setting the function pointer field name prefix.

### DIFF
--- a/glad/generator/c/__init__.py
+++ b/glad/generator/c/__init__.py
@@ -111,7 +111,7 @@ def get_debug_impl(command, command_code_name=None):
 def ctx(jinja_context, name, context='context', raw=False, name_only=False, member=False):
     options = jinja_context['options']
 
-    prefix = 'glad_'
+    prefix = options['prefix'] + '_'
     if options['mx']:
         prefix = context + '->'
         if name.startswith('GLAD_'):
@@ -238,6 +238,11 @@ class CConfig(Config):
         converter=bool,
         default=False,
         description='On-demand function pointer loading, initialize on use (experimental)'
+    )
+    PREFIX = ConfigOption(
+        converter=str,
+        default="glad",
+        description='Prefix for generated function pointers (experimental)'
     )
 
     __constraints__ = [

--- a/glad/generator/c/templates/template_utils.h
+++ b/glad/generator/c/templates/template_utils.h
@@ -113,12 +113,12 @@ typedef {{ command.proto.ret|type_to_c }} (GLAD_API_PTR *{{ command.name|pfn }})
 {% macro write_function_declarations(commands, debug=False) %}
 {% for command in commands %}
 {% call protect(command) %}
-GLAD_API_CALL {{ command.name|pfn }} glad_{{ command.name }};
+GLAD_API_CALL {{ command.name|pfn }} {{ options.prefix }}_{{ command.name }};
 {% if debug %}
-GLAD_API_CALL {{ command.name|pfn }} glad_debug_{{ command.name }};
-#define {{ command.name }} glad_debug_{{ command.name }}
+GLAD_API_CALL {{ command.name|pfn }} {{ options.prefix }}_debug_{{ command.name }};
+#define {{ command.name }} {{ options.prefix }}_debug_{{ command.name }}
 {% else %}
-#define {{ command.name }} glad_{{ command.name }}
+#define {{ command.name }} {{ options.prefix }}_{{ command.name }}
 {% endif %}
 {% endcall %}
 {% endfor %}


### PR DESCRIPTION
To avoid symbol conflicts.

I don't super love my implementation here because it encodes the whole "prefix + _ + name" thing in more than one place, but it doesn't make it less DRY than it was before.