### PR TITLE
Ninja: Fixed "duplicate build rules" error

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -138,6 +138,7 @@ function(__glad_c_library CARGS CFILES)
             message(FATAL_ERROR "Unknown SPEC: '${SPEC}'")
         endif()
     endforeach()
+    list(REMOVE_DUPLICATES GGC_FILES)
 
     set(GGC_ARGS "")
     if(GGC_ALIAS)


### PR DESCRIPTION
When building cmake-projects using ninja as generator and if multiple APIs are specified, khrplatform.h is added multiple times to the list of files to compile. This triggers an error in ninja: "duplicate build rules".
Simply removing duplicate files from the GGC_FILES list fixes this issue.