### PR TITLE
c: correct name of unload-function

### DIFF
--- a/glad/lang/c/loader/wgl.py
+++ b/glad/lang/c/loader/wgl.py
@@ -14,7 +14,7 @@ int gladLoadWGL(HDC hdc) {
     return status;
 }
 
-void gladUnloadGLX(void) {
+void gladUnloadWGL(void) {
     close_wgl();
 }
 '''


### PR DESCRIPTION
This is named gladUnloadWGL in the header file, and the corresponding load-function also has a WGL suffix. So it seems safe to assume that the GLX suffix is a typo.