### PR TITLE
Honor BUILD_SHARED_LIBS behavior

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -256,6 +256,8 @@ function(glad_add_library TARGET)
         list(APPEND GLAD_ADD_LIBRARY_ARGS MODULE)
     elseif(GG_INTERFACE)
         list(APPEND GLAD_ADD_LIBRARY_ARGS INTERFACE)
+    elseif(BUILD_SHARED_LIBS)
+        set(GG_SHARED TRUE)
     endif()
 
     if(GG_EXCLUDE_FROM_ALL)


### PR DESCRIPTION
When running cmake with -DBUILD_SHARED_LIBS=ON glad is not built
as shared library. This change fixes that.

Signed-off-by: rafalmaziejuk <rafalmaziejuk@gmail.com>
