### PR TITLE
Add argument names to function declarations

### DIFF
--- a/glad/generator/c/templates/template_utils.h
+++ b/glad/generator/c/templates/template_utils.h
@@ -116,9 +116,9 @@ typedef {{ command.proto.ret|type_to_c }} (GLAD_API_PTR *{{ command.name|pfn }})
 GLAD_API_CALL {{ command.name|pfn }} glad_{{ command.name }};
 {% if debug %}
 GLAD_API_CALL {{ command.name|pfn }} glad_debug_{{ command.name }};
-#define {{ command.name }} glad_debug_{{ command.name }}
+#define {{ command.name }}({{ command.params|param_names }}) glad_debug_{{ command.name }}({{ command.params|param_names }})
 {% else %}
-#define {{ command.name }} glad_{{ command.name }}
+#define {{ command.name }}({{ command.params|param_names }}) glad_{{ command.name }}({{ command.params|param_names }})
 {% endif %}
 {% endcall %}
 {% endfor %}


### PR DESCRIPTION
This PR changes `#define`s of function declarations (effectively aliases) to function-like macros, so that at least parameter names are visible in editors like VSCode with `clangd` (which can't expand macros further than 1-level depth, apparently).

Before:
```cpp
GLAD_API_CALL PFNGLGETERRORPROC glad_glGetError;
#define glGetError glad_glGetError
GLAD_API_CALL PFNGLUNIFORM4UIPROC glad_glUniform4ui;
#define glUniform4ui glad_glUniform4ui
GLAD_API_CALL PFNGLUSEPROGRAMPROC glad_glUseProgram;
#define glUseProgram glad_glUseProgram
```

![410855250_726743109039864_8198493770215275128_n](https://github.com/Dav1dde/glad/assets/67486508/2d70d424-4a7a-4ff6-ae43-b9525342128d)



After:
```cpp
GLAD_API_CALL PFNGLGETERRORPROC glad_glGetError;
#define glGetError() glad_glGetError()
GLAD_API_CALL PFNGLUNIFORM4UIPROC glad_glUniform4ui;
#define glUniform4ui(location, v0, v1, v2, v3) glad_glUniform4ui(location, v0, v1, v2, v3)
GLAD_API_CALL PFNGLUSEPROGRAMPROC glad_glUseProgram;
#define glUseProgram(program) glad_glUseProgram(program)
```

![403401978_1568828770520487_5287887910017992645_n](https://github.com/Dav1dde/glad/assets/67486508/adee5b19-2178-4f6f-9976-14224ce741af)


There is a slight possibility, that it could also prevent false-positive compilations when passed an invalid number of arguments to functions in heavily templated code. Hopefully function macros might help mitigate that.