### PR TITLE
Defined GLAD_GL_IMPLEMENTATION to GLFW example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ dist/
 /rust/
 target/
 Cargo.lock
+.vscode/

--- a/example/c/gl_glfw.c
+++ b/example/c/gl_glfw.c
@@ -1,10 +1,11 @@
+#include <stdlib.h>
+#include <stdio.h>
+
 #define GLAD_GL_IMPLEMENTATION // Necessary for headeronly version.
 #include <glad/gl.h>
 
 #include <GLFW/glfw3.h>
 
-#include <stdlib.h>
-#include <stdio.h>
 
 const GLuint WIDTH = 800, HEIGHT = 600;
 

--- a/example/c/gl_glfw.c
+++ b/example/c/gl_glfw.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#define GLAD_GL_IMPLEMENTATION
 #include <glad/gl.h>
 
 #include <GLFW/glfw3.h>

--- a/example/c/gl_glfw.c
+++ b/example/c/gl_glfw.c
@@ -1,7 +1,6 @@
-#define GLAD_GL_IMPLEMENTATION
+#define GLAD_GL_IMPLEMENTATION // Necessary for headeronly version.
 #include <glad/gl.h>
 
-#define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
 
 #include <stdlib.h>

--- a/example/c/gl_glfw.c
+++ b/example/c/gl_glfw.c
@@ -1,11 +1,11 @@
-#include <stdlib.h>
-#include <stdio.h>
-
 #define GLAD_GL_IMPLEMENTATION
 #include <glad/gl.h>
 
+#define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
 
+#include <stdlib.h>
+#include <stdio.h>
 
 const GLuint WIDTH = 800, HEIGHT = 600;
 


### PR DESCRIPTION
Patch for issue #463 which can cause portability issues in the future by defining `GLAD_GL_IMPLEMENTATION` before glad import in GLFW example.

This patch does not stress nor attempt to fix any issues with the library itself, but edits the example in question so consumers don’t make the mistake of not defining the required macro.

> An alternative solution might be to include GLFW before glad, but I haven’t had the chance to confirm. Don’t take my word for it.

Also added .vscode to .gitignore. If this is
an issue please let me know so I can remove
it before the pull.

Thank you @Dav1dde for helping me troubleshoot the version checking issue.

