### PR TITLE
ci: bump actions versions

### DIFF
--- a/.github/workflows/glad2.yaml
+++ b/.github/workflows/glad2.yaml
@@ -7,8 +7,8 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - name: Install Python dependencies


### PR DESCRIPTION
Fix the following warning:
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.