### PR TITLE
Use a base function pointer instead of a regular pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ struct gladGLversionStruct {
 
 extern struct gladGLversionStruct GLVersion;
 
-typedef void* (* GLADloadproc)(const char *name);
+typedef void (* GLADbasefp)(void);
+typedef GLADbasefp (* GLADloadproc)(const char *name);
 
 /*
  * Load OpenGL using the internal loader.

--- a/glad/lang/c/loader/__init__.py
+++ b/glad/lang/c/loader/__init__.py
@@ -1,6 +1,6 @@
 
 LOAD_OPENGL_DLL = '''
-%(pre)s void* %(proc)s(const char *namez);
+%(pre)s GLADbasefp %(proc)s(const char *namez);
 
 #if defined(_WIN32) || defined(__CYGWIN__)
 #ifndef _WINDOWS_
@@ -101,7 +101,7 @@ void %(terminate)s(void) {
 #endif
 
 %(pre)s
-void* %(proc)s(const char *namez) {
+GLADbasefp %(proc)s(const char *namez) {
     void* result = NULL;
     if(libGL == NULL) return NULL;
 

--- a/glad/lang/c/loader/egl.py
+++ b/glad/lang/c/loader/egl.py
@@ -35,7 +35,8 @@ _EGL_HEADER = '''
 extern "C" {
 #endif
 
-typedef void* (* GLADloadproc)(const char *name);
+typedef void (* GLADbasefp)(void);
+typedef GLADbasefp (* GLADloadproc)(const char *name);
 '''
 
 _EGL_HEADER_LOADER = '''

--- a/glad/lang/c/loader/gl.py
+++ b/glad/lang/c/loader/gl.py
@@ -157,7 +157,8 @@ struct gladGLversionStruct {
     int minor;
 };
 
-typedef void* (* GLADloadproc)(const char *name);
+typedef void (* GLADbasefp)(void);
+typedef GLADbasefp (* GLADloadproc)(const char *name);
 ''' + LOAD_OPENGL_GLAPI_H + '''
 GLAPI struct gladGLversionStruct GLVersion;
 '''

--- a/glad/lang/c/loader/glx.py
+++ b/glad/lang/c/loader/glx.py
@@ -48,7 +48,8 @@ _WGL_HEADER_MID = '''
 extern "C" {
 #endif
 
-typedef void* (* GLADloadproc)(const char *name);
+typedef void (* GLADbasefp)(void);
+typedef GLADbasefp (* GLADloadproc)(const char *name);
 ''' + LOAD_OPENGL_GLAPI_H
 
 _GLX_HEADER_LOADER = '''

--- a/glad/lang/c/loader/wgl.py
+++ b/glad/lang/c/loader/wgl.py
@@ -55,7 +55,8 @@ _WGL_HEADER_MID = '''
 extern "C" {
 #endif
 
-typedef void* (* GLADloadproc)(const char *name);
+typedef void (* GLADbasefp)(void);
+typedef GLADbasefp (* GLADloadproc)(const char *name);
 ''' + LOAD_OPENGL_GLAPI_H
 
 _WGL_HEADER_LOADER = '''


### PR DESCRIPTION
Passing the function pointers with regular pointers result in undefined behaviour. Before this commit, UBSan Clang Sanitizer catches this issue.

I think casting function pointers back to their original signatures from the base pointer does not result in undefined behaviour. At least UBSan does not complain after these changes.

This commit should not affect existing dependants because it introduces a single type `GLADbasefp` and it's used to change the return type of existing API only. Better test it though!