### PR TITLE
Close Win32 Window Properly in WGL Example

### DIFF
--- a/example/c/wgl.c
+++ b/example/c/wgl.c
@@ -158,8 +158,10 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
     switch (uMsg) {
     case WM_QUIT:
-    case WM_DESTROY:
     case WM_CLOSE:
+        DestroyWindow(hWnd);
+        break;
+    case WM_DESTROY:
         PostQuitMessage(0);
         break;
     default:


### PR DESCRIPTION
The created window in this example would not close when the 'x' button was pressed.  Fixed the handling of WM_CLOSE and WM_QUIT to be DestroyWindow(hWnd) instead of PostQuitMessage(0).

Source: https://learn.microsoft.com/en-us/windows/win32/learnwin32/closing-the-window .