### PR TITLE
Add glfwInit() and glfwTerminate() in README snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Some languages are only available in the [glad1 generator](https://glad.dav1d.de
 int main() {
     // -- snip --
 
+    if (!glfwInit()) {
+        printf("Failed to initialize glfw\n");
+        return -1;
+    }
+
     GLFWwindow* window = glfwCreateWindow(WIDTH, HEIGHT, "LearnOpenGL", NULL, NULL);
     glfwMakeContextCurrent(window);
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ int main() {
     // Successfully loaded OpenGL
     printf("Loaded OpenGL %d.%d\n", GLAD_VERSION_MAJOR(version), GLAD_VERSION_MINOR(version));
 
+    glfwTerminate();
+
     // -- snip --
 }
 ```


### PR DESCRIPTION
Adds `glfwInit()` and `glfwTerminate()` in README snippet to help people who use the example to get started.