### PR TITLE
Added documentation generation for C

### DIFF
--- a/glad/generator/c/__init__.py
+++ b/glad/generator/c/__init__.py
@@ -244,6 +244,11 @@ class CConfig(Config):
         default=False,
         description='On-demand function pointer loading, initialize on use (experimental)'
     )
+    DOCUMENTED = ConfigOption(
+        converter=bool,
+        default=False,
+        description='Add generated type documentation to all functions'
+    )
 
     __constraints__ = [
         # RequirementConstraint(['MX_GLOBAL'], 'MX'),

--- a/glad/generator/c/templates/template_utils.h
+++ b/glad/generator/c/templates/template_utils.h
@@ -114,6 +114,15 @@ typedef {{ command.proto.ret|type_to_c }} (GLAD_API_PTR *{{ command.name|pfn }})
 {% for command in commands %}
 {% call protect(command) %}
 GLAD_API_CALL {{ command.name|pfn }} glad_{{ command.name }};
+{% if options.documented %}
+/**
+ * @brief `{{ command.proto.ret|type_to_c }} {{ command.name }}({{ command.params|params_to_c }})`
+{% for param in command.params %}
+ * @param {{param.name}} {{ param.type|type_to_c }}
+{% endfor %}
+ * @returns {{ command.proto.ret|type_to_c }}
+ */
+{% endif %}
 {% if debug %}
 GLAD_API_CALL {{ command.name|pfn }} glad_debug_{{ command.name }};
 #define {{ command.name }} glad_debug_{{ command.name }}


### PR DESCRIPTION
Hello! I added Doxygen-style comment generation for C, I found I needed it for VS Code because it won't resolve the macro and show me the actual types. I bet there's better ways to implement this within Glad, but this worked for my needs and I thought I would at least put this out there.