### PR TITLE
[experiment] rework c opengl extensions loading + allow force core profile in less than GL 3.2

### DIFF
--- a/glad/generator/c/templates/gl.c
+++ b/glad/generator/c/templates/gl.c
@@ -69,7 +69,7 @@ static void glad_gl_activate_extension(unsigned int *flags, unsigned int *crc32,
     
     while (left < right) {
         int mid = left + (right - left) / 2;
-        // Upper-Bound Search
+        // Lower-Bound Search
         if (crc32[mid] < hash) {
             left = mid + 1;
         } else {

--- a/glad/generator/c/templates/gl.c
+++ b/glad/generator/c/templates/gl.c
@@ -36,110 +36,111 @@ static void _post_call_{{ feature_set.name }}_callback_default(void *ret, const 
 
 
 {% block loader %}
-static void glad_gl_free_extensions(char **exts_i) {
-    if (exts_i != NULL) {
-        unsigned int index;
-        for(index = 0; exts_i[index]; index++) {
-            free((void *) (exts_i[index]));
-        }
-        free((void *)exts_i);
-        exts_i = NULL;
-    }
-}
-static int glad_gl_get_extensions({{ template_utils.context_arg(',') }} const char **out_exts, char ***out_exts_i) {
-#if defined(GL_ES_VERSION_3_0) || defined(GL_VERSION_3_0)
-    if ({{ 'glGetStringi'|ctx }} != NULL && {{ 'glGetIntegerv'|ctx }} != NULL) {
-        unsigned int index = 0;
-        unsigned int num_exts_i = 0;
-        char **exts_i = NULL;
-        {{ 'glGetIntegerv'|ctx }}(GL_NUM_EXTENSIONS, (int*) &num_exts_i);
-        exts_i = (char **) malloc((num_exts_i + 1) * (sizeof *exts_i));
-        if (exts_i == NULL) {
-            return 0;
-        }
-        for(index = 0; index < num_exts_i; index++) {
-            const char *gl_str_tmp = (const char*) {{ 'glGetStringi'|ctx }}(GL_EXTENSIONS, index);
-            size_t len = strlen(gl_str_tmp) + 1;
 
-            char *local_str = (char*) malloc(len * sizeof(char));
-            if(local_str == NULL) {
-                exts_i[index] = NULL;
-                glad_gl_free_extensions(exts_i);
-                return 0;
-            }
+// -------------------------------
+// GLAD OpenGL Extensions: Hashing
+// -------------------------------
 
-            memcpy(local_str, gl_str_tmp, len * sizeof(char));
-            exts_i[index] = local_str;
-        }
-        exts_i[index] = NULL;
+static unsigned int glad_gl_crc32_extension(const unsigned char *name) {
+   unsigned int byte, crc, mask;
+   int i, j;
 
-        *out_exts_i = exts_i;
-
-        return 1;
-    }
-#else
-    GLAD_UNUSED(out_exts_i);
-#endif
-    if ({{ 'glGetString'|ctx }} == NULL) {
-        return 0;
-    }
-    *out_exts = (const char *){{ 'glGetString'|ctx }}(GL_EXTENSIONS);
-    return 1;
-}
-static int glad_gl_has_extension(const char *exts, char **exts_i, const char *ext) {
-    if(exts_i) {
-        unsigned int index;
-        for(index = 0; exts_i[index]; index++) {
-            const char *e = exts_i[index];
-            if(strcmp(e, ext) == 0) {
-                return 1;
-            }
-        }
-    } else {
-        const char *extensions;
-        const char *loc;
-        const char *terminator;
-        extensions = exts;
-        if(extensions == NULL || ext == NULL) {
-            return 0;
-        }
-        while(1) {
-            loc = strstr(extensions, ext);
-            if(loc == NULL) {
-                return 0;
-            }
-            terminator = loc + strlen(ext);
-            if((loc == extensions || *(loc - 1) == ' ') &&
-                (*terminator == ' ' || *terminator == '\0')) {
-                return 1;
-            }
-            extensions = terminator;
-        }
-    }
-    return 0;
+   i = 0;
+   crc = 0xFFFFFFFF;
+   while (name[i] != 0) {
+      byte = name[i]; // Get next byte.
+      crc = crc ^ byte;
+      for (j = 7; j >= 0; j--) { // Do eight times.
+         mask = -(crc & 1);
+         crc = (crc >> 1) ^ (0xEDB88320 & mask);
+      }
+      i = i + 1;
+   }
+   return ~crc;
 }
 
-static GLADapiproc glad_gl_get_proc_from_userptr(void *userptr, const char* name) {
-    return (GLAD_GNUC_EXTENSION (GLADapiproc (*)(const char *name)) userptr)(name);
+static void glad_gl_activate_extension(unsigned int *flags, unsigned int *crc32, int count, const char *name) {
+    if (name[0] == '\0') return;
+    int left = 0;
+    int right = count;
+    // Calculate extension name crc32 hash
+    unsigned int hash = glad_gl_crc32_extension(
+        (const unsigned char*) name);
+    
+    while (left < right) {
+        int mid = left + (right - left) / 2;
+        // Upper-Bound Search
+        if (crc32[mid] < hash) {
+            left = mid + 1;
+        } else {
+            right = mid;
+        }
+    }
+    
+    // Activate if Extension was Found
+    if (left < count && hash == crc32[left])
+        flags[left] = 0xFFFFFFFF;
 }
+
+// --------------------------------
+// GLAD OpenGL Extensions: Checking
+// --------------------------------
+
+// XXX: we can assume these functions are forever ABI stable in OpenGL nowadays
+typedef const GLubyte * (GLAD_API_PTR *GLAD__PFNGLGETSTRINGPROC)(GLenum name);
+typedef const GLubyte * (GLAD_API_PTR *GLAD__PFNGLGETSTRINGIPROC)(GLenum name, GLuint index);
+typedef void (GLAD_API_PTR *GLAD__PFNGLGETINTEGERVPROC)(GLenum pname, GLint * data);
+static GLAD__PFNGLGETSTRINGPROC glad__glGetString = NULL;
+static GLAD__PFNGLGETSTRINGIPROC glad__glGetStringi = NULL;
+static GLAD__PFNGLGETINTEGERVPROC glad__glGetIntegerv = NULL;
+#define GLAD__NUM_EXTENSIONS 0x821D
+#define GLAD__EXTENSIONS 0x1F03
+
+static void glad_gl_check_extensions(unsigned int *flags, unsigned int *crc32, int count) {
+    if (count == 0) return;
+    if (glad__glGetStringi != NULL && glad__glGetIntegerv != NULL) {
+        unsigned int num_exts = 0;
+        glad__glGetIntegerv(GLAD__NUM_EXTENSIONS, (int*) &num_exts);
+        if (num_exts == 0) goto GLAD__EXTENSIONS_WORKAROUND;
+        // Iterate Extensions and Find Available
+        for (unsigned int idx = 0; idx < num_exts; idx++) {
+            const char *name = (const char*) glad__glGetStringi(GLAD__EXTENSIONS, idx);
+            glad_gl_activate_extension(flags, crc32, count, name);
+        }
+    // Workaround for old OpenGL ES
+    } else if (glad__glGetString != NULL) {
+GLAD__EXTENSIONS_WORKAROUND:
+        const char *extensions = (const char *)
+            glad__glGetString(GLAD__EXTENSIONS);
+        // Prepare Extensions Buffer
+        char* ext = (char*) extensions;
+        char name[1024];
+        int idx = 0;
+        // Get Extensions
+        while (1) {
+            char letter = *ext++;
+            if (letter == ' ' || letter == '\0') {
+                name[idx] = '\0';
+                if (name[0] != '\0')
+                    glad_gl_activate_extension(
+                        flags, crc32, count, name);
+                // Exit Extensions Loop
+                idx = 0;
+                if (letter == '\0')
+                    break;
+            } else {
+                name[idx] = letter;
+                idx++;
+            }
+        }
+    }
+}
+
+// ----------------------
+// GLAD OpenGL Extensions
+// ----------------------
 
 {% for api in feature_set.info.apis %}
-static int glad_gl_find_extensions_{{ api|lower }}({{ template_utils.context_arg(def='void') }}) {
-    const char *exts = NULL;
-    char **exts_i = NULL;
-    if (!glad_gl_get_extensions({{ 'context, ' if options.mx }}&exts, &exts_i)) return 0;
-
-{% for extension in feature_set.extensions|select('supports', api) %}
-    {{ ('GLAD_' + extension.name)|ctx(name_only=True) }} = glad_gl_has_extension(exts, exts_i, "{{ extension.name }}");
-{% else %}
-    GLAD_UNUSED(&glad_gl_has_extension);
-{% endfor %}
-
-    glad_gl_free_extensions(exts_i);
-
-    return 1;
-}
-
 static int glad_gl_find_core_{{ api|lower }}({{ template_utils.context_arg(def='void') }}) {
     int i;
     const char* version;
@@ -152,7 +153,7 @@ static int glad_gl_find_core_{{ api|lower }}({{ template_utils.context_arg(def='
     };
     int major = 0;
     int minor = 0;
-    version = (const char*) {{ 'glGetString'|ctx }}(GL_VERSION);
+    version = (const char*) glad__glGetString(GL_VERSION);
     if (!version) return 0;
     for (i = 0;  prefixes[i];  i++) {
         const size_t length = strlen(prefixes[i]);
@@ -163,26 +164,45 @@ static int glad_gl_find_core_{{ api|lower }}({{ template_utils.context_arg(def='
     }
 
     GLAD_IMPL_UTIL_SSCANF(version, "%d.%d", &major, &minor);
-
 {% for feature in feature_set.features|select('supports', api) %}
     {{ ('GLAD_' + feature.name)|ctx(name_only=True) }} = (major == {{ feature.version.major }} && minor >= {{ feature.version.minor }}) || major > {{ feature.version.major }};
 {% endfor %}
-
     return GLAD_MAKE_VERSION(major, minor);
 }
+
+static unsigned int glad_gl_crc32_extensions_{{ api|lower }}[] = {
+    {% for extension in feature_set.extensions_crc32|select('supports', api) %}
+        {{"%#x" | format(extension.hash)}}, // {{extension.name}}
+    {% endfor %}
+        0xffffffff
+};
+
+static void glad_gl_find_extensions_{{ api|lower }}({{ template_utils.context_arg(def='void') }}) {
+    unsigned int glad_gl_flags_extensions_{{ api|lower }}[{{feature_set.extensions|length + 1}}] = {0};
+    glad_gl_check_extensions(glad_gl_flags_extensions_{{ api|lower }}, glad_gl_crc32_extensions_{{ api|lower }}, {{feature_set.extensions|length}});
+{% for extension in feature_set.extensions_crc32|select('supports', api) %}
+    {{ ('GLAD_' + extension.name)|ctx(name_only=True) }} = (glad_gl_flags_extensions_{{ api|lower }}[{{loop.index - 1}}] != 0);
+{% endfor %}
+}
+
+// ------------------
+// GLAD OpenGL Loader
+// ------------------
 
 int gladLoad{{ api|api }}{{ 'Context' if options.mx }}UserPtr({{ template_utils.context_arg(',') }} GLADuserptrloadfunc load, void *userptr) {
     int version;
 
-    {{ 'glGetString'|ctx }} = (PFNGLGETSTRINGPROC) load(userptr, "glGetString");
-    if({{ 'glGetString'|ctx }} == NULL) return 0;
-    version = glad_gl_find_core_{{ api|lower }}({{ 'context' if options.mx }});
+    glad__glGetString = (GLAD__PFNGLGETSTRINGPROC) load(userptr, "glGetString");
+    glad__glGetStringi = (GLAD__PFNGLGETSTRINGIPROC) load(userptr, "glGetStringi");
+    glad__glGetIntegerv = (GLAD__PFNGLGETINTEGERVPROC) load(userptr, "glGetIntegerv");
+    if(glad__glGetString == NULL) return 0;
 
+    version = glad_gl_find_core_{{ api|lower }}({{ 'context' if options.mx }});
 {% for feature, _ in loadable(feature_set.features, api=api) %}
     glad_gl_load_{{ feature.name }}({{'context, ' if options.mx }}load, userptr);
 {% endfor %}
 
-    if (!glad_gl_find_extensions_{{ api|lower }}({{ 'context' if options.mx }})) return 0;
+    glad_gl_find_extensions_{{ api|lower }}({{ 'context' if options.mx }});
 {% for extension, _ in loadable(feature_set.extensions, api=api) %}
     glad_gl_load_{{ extension.name }}({{'context, ' if options.mx }}load, userptr);
 {% endfor %}
@@ -203,6 +223,10 @@ int gladLoad{{ api|api }}UserPtr(GLADuserptrloadfunc load, void *userptr) {
     return gladLoad{{ api|api }}ContextUserPtr(gladGet{{ feature_set.name|api }}Context(), load, userptr);
 }
 {% endif %}
+
+static GLADapiproc glad_gl_get_proc_from_userptr(void *userptr, const char* name) {
+    return (GLAD_GNUC_EXTENSION (GLADapiproc (*)(const char *name)) userptr)(name);
+}
 
 int gladLoad{{ api|api }}{{ 'Context' if options.mx }}({{ template_utils.context_arg(',') }} GLADloadfunc load) {
     return gladLoad{{ api|api }}{{ 'Context' if options.mx }}UserPtr({{'context,' if options.mx }} glad_gl_get_proc_from_userptr, GLAD_GNUC_EXTENSION (void*) load);

--- a/glad/parse.py
+++ b/glad/parse.py
@@ -746,6 +746,15 @@ class Specification(object):
                         (remove.api is None or remove.api == api)):
                     result = result.difference(remove.removes)
 
+        # Force Core Profile removal deprecated even in older versions
+        if api == 'gl' and version < Version(major=3, minor=2):
+            found_core = self.features['gl'][Version(major=3, minor=2)]
+            # Remove Deprecated Extensions that could be forgetten even in 2.x
+            for remove in getattr(found_core, 'removes', []):
+                if ((remove.profile is None or remove.profile == profile) and
+                        (remove.api is None or remove.api == api)):
+                    result = result.difference(remove.removes)
+
         # At this point one could hope that the XML files would be sane, but of course they are not!?
         # There is a builtin requirement system which is used for functions and enums,
         # but only partially for types WHY!??!?!?!??!?!

--- a/glad/parse.py
+++ b/glad/parse.py
@@ -29,7 +29,7 @@ from contextlib import closing
 from itertools import chain
 
 from glad.opener import URLOpener
-from glad.util import Version, topological_sort, memoize
+from glad.util import Version, extension_crc32, topological_sort, memoize
 import glad.util
 
 logger = logging.getLogger(__name__)
@@ -79,6 +79,8 @@ class FeatureSet(object):
         self.info = info
         self.features = features
         self.extensions = extensions
+        self.extensions_crc32 = sorted(extensions, key=lambda x: x.hash)
+        # glad features
         self.types = types
         self.enums = enums
         self.commands = commands
@@ -1357,6 +1359,7 @@ class Extension(IdentifiedByName):
     def __init__(self, name, supported=None, requires=None,
                  type_=None, protect=None, platform=None):
         self.name = name
+        self.hash = extension_crc32(name)
         self.supported = supported
         self.requires = requires or []
         self.type = type_

--- a/glad/util.py
+++ b/glad/util.py
@@ -4,14 +4,26 @@ import re
 import sys
 from collections import namedtuple, defaultdict
 
+def extension_crc32(message):
+    chars = message.encode('ascii')
+    crc = 0xFFFFFFFF
+    i, j = 0, 0
+    byte, mask = 0, 0
+    # Generate CRC32 Hashing
+    for c in chars:
+        crc = crc ^ c
+        for i in range(8):
+            crc = crc & 0xFFFFFFFF
+            mask = (-(crc & 1)) & 0xFFFFFFFF
+            crc = (crc >> 1) ^ (0xEDB88320 & mask)
+    # Return Generated Hash
+    return (~crc) & 0xFFFFFFFF
 
 if sys.version_info >= (3, 0, 0):
     basestring = str
 
-
 Version = namedtuple('Version', ['major', 'minor'])
 ExpandedName = namedtuple('ExpandedName', ['prefix', 'suffix'])
-
 
 _API_NAMES = {
     'egl': 'EGL',
@@ -22,7 +34,6 @@ _API_NAMES = {
     'glx': 'GLX',
     'wgl': 'WGL',
 }
-
 
 def api_name(api):
     api = api.lower()


### PR DESCRIPTION
fixes #492 
- rework c glad opengl extension loading using a generated constant ordered crc32 hash table from selected extension names, this removes the needing of malloc each extension name temporaly and brute-force string compare because searching in the table is just using "lower-bound" search at the iteration of each opengl extension name
- additionally allow core profile remove deprecate procs even from older versions than opengl 3.2
for example `--api='gl:core=2.1'` gonna remove `glBegin`, `glEnd`, etc. from opengl 2.1

example of the generated code:
```c
static unsigned int glad_gl_crc32_extensions_gl[] = {
        0x22eb0518, // GL_ARB_gl_spirv
        0x299a86ca, // GL_ARB_texture_compression_bptc
        0x3f22171c, // GL_EXT_texture_compression_s3tc
        0x4a03d323, // GL_ARB_texture_buffer_range
        0x56ea549b, // GL_ARB_texture_storage_multisample
        0x67b4f8bb, // GL_ARB_shader_storage_buffer_object
        0x7a21b127, // GL_ARB_shader_atomic_counters
        0x7b80afe6, // GL_ARB_texture_cube_map_array
        0x8a58e0da, // GL_ARB_spirv_extensions
        0x98127c6a, // GL_ARB_get_texture_sub_image
        0xb04ac249, // GL_ARB_compute_shader
        0xb9ab7373, // GL_ARB_ES3_compatibility
        0xc4e4e799, // GL_ARB_texture_storage
        0xc8a531f1, // GL_ARB_debug_output
        0xe47cbcf8, // GL_ARB_shader_image_size
        0xe9fdddb4, // GL_KHR_texture_compression_astc_ldr
        0xeef47568, // GL_KHR_texture_compression_astc_hdr
        0xf48228f4, // GL_ARB_shader_image_load_store
        0xffffffff
};

static void glad_gl_find_extensions_gl(void) {
    unsigned int glad_gl_flags_extensions_gl[19] = {0};
    glad_gl_check_extensions(glad_gl_flags_extensions_gl, glad_gl_crc32_extensions_gl, 18);
    GLAD_GL_ARB_gl_spirv = (glad_gl_flags_extensions_gl[0] != 0);
    GLAD_GL_ARB_texture_compression_bptc = (glad_gl_flags_extensions_gl[1] != 0);
    GLAD_GL_EXT_texture_compression_s3tc = (glad_gl_flags_extensions_gl[2] != 0);
    GLAD_GL_ARB_texture_buffer_range = (glad_gl_flags_extensions_gl[3] != 0);
    GLAD_GL_ARB_texture_storage_multisample = (glad_gl_flags_extensions_gl[4] != 0);
    GLAD_GL_ARB_shader_storage_buffer_object = (glad_gl_flags_extensions_gl[5] != 0);
    GLAD_GL_ARB_shader_atomic_counters = (glad_gl_flags_extensions_gl[6] != 0);
    GLAD_GL_ARB_texture_cube_map_array = (glad_gl_flags_extensions_gl[7] != 0);
    GLAD_GL_ARB_spirv_extensions = (glad_gl_flags_extensions_gl[8] != 0);
    GLAD_GL_ARB_get_texture_sub_image = (glad_gl_flags_extensions_gl[9] != 0);
    GLAD_GL_ARB_compute_shader = (glad_gl_flags_extensions_gl[10] != 0);
    GLAD_GL_ARB_ES3_compatibility = (glad_gl_flags_extensions_gl[11] != 0);
    GLAD_GL_ARB_texture_storage = (glad_gl_flags_extensions_gl[12] != 0);
    GLAD_GL_ARB_debug_output = (glad_gl_flags_extensions_gl[13] != 0);
    GLAD_GL_ARB_shader_image_size = (glad_gl_flags_extensions_gl[14] != 0);
    GLAD_GL_KHR_texture_compression_astc_ldr = (glad_gl_flags_extensions_gl[15] != 0);
    GLAD_GL_KHR_texture_compression_astc_hdr = (glad_gl_flags_extensions_gl[16] != 0);
    GLAD_GL_ARB_shader_image_load_store = (glad_gl_flags_extensions_gl[17] != 0);
}
```
