### PR TITLE
example: adds SDL3 example (callback main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Examples can be found [in the example directory](/example). Some examples:
     * [GL GLFW](example/c/gl_glfw.c)
     * [GL GLFW On-Demand loading](example/c/gl_glfw_on_demand.c)
     * [GL GLFW Multiple Windows/Contexts](example/c++/multiwin_mx/)
+    * [GL SDL3 Callbacks](example/c/gl_sdl3_callbacks.c)
     * [GL SDL3](example/c/gl_sdl3.c)
     * [GL SDL2](example/c/gl_sdl2.c)
     * [Vulkan GLFW](example/c/vulkan_tri_glfw/)

--- a/example/c/gl_sdl3_callbacks.c
+++ b/example/c/gl_sdl3_callbacks.c
@@ -1,0 +1,78 @@
+// gcc $(pkg-config --cflags --libs sdl3) -I${GLAD_PATH}/include gl_sdl3_callbacks.c ${GLAD_PATH}/src/gl.c
+//
+// Based on https://examples.libsdl.org/SDL3/renderer/01-clear/
+//
+#include <stdio.h>
+#include <glad/gl.h>
+
+#define SDL_MAIN_USE_CALLBACKS 1
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_main.h>
+
+static const GLuint WIDTH = 800, HEIGHT = 600;
+
+static SDL_Window *window;
+static SDL_Renderer *renderer;
+static SDL_GLContext GLContext;
+
+SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
+{
+    SDL_SetAppMetadata("GLAD SDL3 example", "1.0", "sh.glad.gen.sdl3.callbacks");
+
+    if (!SDL_Init(SDL_INIT_VIDEO)) {
+        SDL_Log("Couldn't initialize SDL: %s", SDL_GetError());
+        return SDL_APP_FAILURE;
+    }
+
+    SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+
+    if (!SDL_CreateWindowAndRenderer("[glad] GL with SDL3 callback main", WIDTH, HEIGHT, SDL_WINDOW_RESIZABLE | SDL_WINDOW_OPENGL, &window, &renderer)) {
+        SDL_Log("Couldn't create window/renderer: %s", SDL_GetError());
+        return SDL_APP_FAILURE;
+    }
+
+    GLContext = SDL_GL_CreateContext(window);
+
+    int version = gladLoadGL((GLADloadfunc) SDL_GL_GetProcAddress);
+    printf("GL %d.%d\n", GLAD_VERSION_MAJOR(version), GLAD_VERSION_MINOR(version));
+
+    return SDL_APP_CONTINUE;
+}
+
+SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
+{
+    if (event->type == SDL_EVENT_QUIT) {
+        return SDL_APP_SUCCESS;
+    }
+
+    if (event->type == SDL_EVENT_KEY_DOWN && event->key.key == SDLK_ESCAPE) {
+        return SDL_APP_SUCCESS;
+    }
+
+    return SDL_APP_CONTINUE;
+}
+
+SDL_AppResult SDL_AppIterate(void *appstate)
+{
+    const double now = ((double)SDL_GetTicks()) / SDL_MS_PER_SECOND;
+
+    const float red = (float) (0.5 + 0.5 * SDL_sin(now));
+    const float green = (float) (0.5 + 0.5 * SDL_sin(now + SDL_PI_D * 2 / 3));
+    const float blue = (float) (0.5 + 0.5 * SDL_sin(now + SDL_PI_D * 4 / 3));
+
+    glClearColor(red, green, blue, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+
+    SDL_GL_SwapWindow(window);
+
+    return SDL_APP_CONTINUE;
+}
+
+void SDL_AppQuit(void *appstate, SDL_AppResult result)
+{
+    SDL_GL_DestroyContext(GLContext);
+    /* SDL will clean up the window/renderer for us. */
+}


### PR DESCRIPTION
As per #532, here's a SDL3 example using [the callback interface](https://wiki.libsdl.org/SDL3/README-main-functions#main-callbacks-in-sdl3).

It's based on the official "[01-clear](https://examples.libsdl.org/SDL3/renderer/01-clear/)" example, but I've cut out some over the most overbearing comments.

I did leave the color-cycling in.