### PR TITLE
c: Try loading OpenGL through EGL if GLX isn't available

### DIFF
--- a/glad/generator/c/templates/loader/gl.c
+++ b/glad/generator/c/templates/loader/gl.c
@@ -44,7 +44,9 @@ static void* glad_gl_dlopen_handle({{ template_utils.context_arg(def='void') }})
         "libGL-1.so",
   #endif
         "libGL.so.1",
-        "libGL.so"
+        "libGL.so",
+        "libEGL.so.1",
+        "libEGL.so"
     };
 #endif
 
@@ -67,6 +69,9 @@ static struct _glad_gl_userptr glad_gl_build_userptr(void *handle) {
 #else
     userptr.gl_get_proc_address_ptr =
         (GLADglprocaddrfunc) glad_dlsym_handle(handle, "glXGetProcAddressARB");
+    if (!userptr.gl_get_proc_address_ptr)
+        userptr.gl_get_proc_address_ptr =
+            (GLADglprocaddrfunc) glad_dlsym_handle(handle, "eglGetProcAddress");
 #endif
 
     return userptr;


### PR DESCRIPTION
On a UNIX system without X11 libraries, it's impossible to have libGL.so and glXGetProcAddressARB(). Currently GLAD would fail to load GL symbols in this case.

Try also loading libEGL.so/libEGL.so.1 in OpenGL loader and fallback to eglGetProcAddress() to query GL symbols if glXGetProcAddressARB() isn't available.

Since EGL version 1.5 released in 2014, it's required for eglGetProcAddress() to be able to query all client API functions instead of only extensions, which is quite early for a Wayland-only display stack, thus no function check or another fallback logic is added.