### PR TITLE
Add --extension-file option to merge additional XML files into the specification

### DIFF
--- a/glad/__main__.py
+++ b/glad/__main__.py
@@ -56,6 +56,11 @@ class GlobalConfig(Config):
                     'a comma separated list of extensions, if missing '
                     'all possible extensions are included.'
     )
+    EXTENSION_FILE = ConfigOption(
+        default=None,
+        description='Path to an optional additional XML extension file or a comma seperated list of paths to merge into the '
+                    'specification (e.g. VK_test_extension.xml).'
+    )
     MERGE = ConfigOption(
         converter=bool,
         default=False,
@@ -156,6 +161,11 @@ def main(args=None):
     specifications = load_specifications(
         [value[0] for value in global_config['API'].values()], opener=opener
     )
+
+    if global_config['EXTENSION_FILE']:
+        for specification in specifications.values():
+            logger.info('merging extension file: %s', global_config['EXTENSION_FILE'])
+            specification.merge_from_file(global_config['EXTENSION_FILE'])
 
     generator = generators[ns.subparser_name](
         global_config['OUT_PATH'], opener=opener, gen_info_factory=gen_info_factory

--- a/glad/__main__.py
+++ b/glad/__main__.py
@@ -35,6 +35,9 @@ def parse_extensions(value):
     value = value.replace(',', ' ')
     return list(filter(None, value.split()))
 
+def parse_extension_files(value):
+    value = value.replace(',', ' ')
+    return list(filter(None, value.split()))
 
 class GlobalConfig(Config):
     OUT_PATH = ConfigOption(
@@ -57,6 +60,7 @@ class GlobalConfig(Config):
                     'all possible extensions are included.'
     )
     EXTENSION_FILE = ConfigOption(
+        converter=parse_extension_files,
         default=None,
         description='Path to an optional additional XML extension file or a comma seperated list of paths to merge into the '
                     'specification (e.g. VK_test_extension.xml).'
@@ -164,8 +168,9 @@ def main(args=None):
 
     if global_config['EXTENSION_FILE']:
         for specification in specifications.values():
-            logger.info('merging extension file: %s', global_config['EXTENSION_FILE'])
-            specification.merge_from_file(global_config['EXTENSION_FILE'])
+            for file in global_config['EXTENSION_FILE']:
+                logger.info('merging extension file: %s', file)
+                specification.merge_from_file(file)
 
     generator = generators[ns.subparser_name](
         global_config['OUT_PATH'], opener=opener, gen_info_factory=gen_info_factory

--- a/glad/parse.py
+++ b/glad/parse.py
@@ -279,6 +279,24 @@ class Specification(object):
         except TypeError:
             return cls(xml_parse(path_or_file_like))
 
+    def merge_from_file(self, path):
+        """
+        Merge additional XML elements from an extension file into this specification.
+        Appends children from <types>, <commands>, <extensions>, and <platforms>
+        sections of the extension file into the corresponding sections of this spec.
+        """
+        ext_root = xml_parse(path)
+        for section_tag in ('types', 'commands', 'extensions', 'platforms'):
+            ext_section = ext_root.find(section_tag)
+            if ext_section is None:
+                continue
+            main_section = self.root.find(section_tag)
+            if main_section is None:
+                self.root.append(ext_section)
+            else:
+                for child in ext_section:
+                    main_section.append(child)
+
     @property
     def comment(self):
         return self.root.find('comment').text


### PR DESCRIPTION
Developers working on Vulkan features not yet merged into vk.xml had no way to test against the spec without modifying it directly.

This adds an --extension-file option that accepts a path (or comma-separated list of paths) to additional XML files, which are merged into vk.xml at runtime — allowing users to prototype and test new extensions without touching the upstream spec.

Usage:
glad --extension-file VK_test_extension.xml ...
glad --extension-file VK_ext_a.xml,VK_ext_b.xml ...