### PR TITLE
ci: fix build and bump action versions

### DIFF
--- a/.github/workflows/glad2.yaml
+++ b/.github/workflows/glad2.yaml
@@ -6,26 +6,29 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    env:
+      WINEDLLOVERRIDES: mscoree,mshtml=
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
+          cache: 'pip'
       - name: Install Python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+        run: pip install -r requirements.txt
       - name: Install dependencies
         run: |
+          # Install wine
+          sudo mkdir -pm755 /etc/apt/keyrings
+          wget -O - https://dl.winehq.org/wine-builds/winehq.key | sudo gpg --dearmor -o /etc/apt/keyrings/winehq-archive.key -
+          sudo dpkg --add-architecture i386
+          sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/noble/winehq-noble.sources
           sudo apt-get update
-          sudo apt-get install gcc g++ gcc-mingw-w64 g++-mingw-w64 rustc libglfw3-dev wine winetricks xvfb libxxf86vm-dev libxi-dev libxcursor-dev libxinerama-dev
+          sudo apt install --install-recommends winehq-stable
+          # Install remaining dependencies
+          sudo apt-get install gcc g++ gcc-mingw-w64 g++-mingw-w64 rustc libglfw3-dev winetricks xvfb libxxf86vm-dev libxi-dev libxcursor-dev libxinerama-dev
       - name: Setup environment
-        run: |
-          mkdir .wine
-          export WINEPREFIX="$(pwd)/.wine"
-          export WINEDLLOVERRIDES="mscoree,mshtml="
-
-          winetricks nocrashdialog
+        run: winetricks nocrashdialog
       - name: Run Tests
         run: PRINT_MESSAGE=1 xvfb-run --auto-servernum ./utility/test.sh
       - name: Publish Test Results


### PR DESCRIPTION
- Bump actions/checkout and actions/setup-python versions to be compatible with Node 24 (https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)
- Skip pip upgrade and cache pip dependencies
- Install a newer wine version to fix the build (from https://gitlab.winehq.org/wine/wine/-/wikis/Debian-Ubuntu)